### PR TITLE
Add generic argument to table to infer column type

### DIFF
--- a/src/components/EzTable/EzTable.tsx
+++ b/src/components/EzTable/EzTable.tsx
@@ -265,7 +265,7 @@ const TablePagination = ({pagination}) => {
  * so that users can look for patterns and insights.
  * They can be embedded in primary content, such as cards.
  */
-const EzTable: React.FC<TableProps> = ({
+const EzTable = <T extends unknown = unknown>({
   actions,
   title,
   subtitle,
@@ -274,7 +274,7 @@ const EzTable: React.FC<TableProps> = ({
   selection,
   onSortClick,
   pagination,
-}) => {
+}: TableProps<T>) => {
   const [allSelected, setAllSelected] = useState(false);
   const selected = selection && items.filter(selection.isRowSelected);
   const numSelectedOnPage = selected && selected.length;
@@ -292,7 +292,7 @@ const EzTable: React.FC<TableProps> = ({
       key = typeof accessor === 'string' ? accessor : undefined,
       component = typeof accessor === 'function'
         ? accessor
-        : ({item}: any) => <Fragment>{item[key]}</Fragment>,
+        : ({item}: {item: T}) => <Fragment>{item[key]}</Fragment>,
       sortable,
       ...rest
     }) => ({

--- a/src/components/EzTable/EzTable.types.ts
+++ b/src/components/EzTable/EzTable.types.ts
@@ -1,4 +1,4 @@
-type Column = {
+type Column<T> = {
   heading: string;
   numeric?: boolean;
   defaultSort?: Direction;
@@ -13,12 +13,15 @@ type Column = {
 
 type Direction = 'asc' | 'desc';
 
-type OnSortClickOptions = {
-  column: Column;
+type OnSortClickOptions<T> = {
+  column: Column<T>;
   direction: Direction;
 };
 
-type onSortClick = (event: React.MouseEvent<HTMLElement>, options: OnSortClickOptions) => void;
+type onSortClick<T> = (
+  event: React.MouseEvent<HTMLElement>,
+  options: OnSortClickOptions<T>
+) => void;
 
 type onRowsPerPageChange = (event: any) => void;
 
@@ -88,26 +91,26 @@ type PaginationSelectionCombination =
   | PaginationAndSelection
   | PaginationAndSelectionDisabled;
 
-type TableBase = {
+type TableBase<T = unknown> = {
   subtitle?: string;
-  columns: Column[];
+  columns: Column<T>[];
   items: any[];
-  onSortClick?: onSortClick;
+  onSortClick?: onSortClick<T>;
 };
 
-export type TableProps = TableBase & TableActions & PaginationSelectionCombination;
+export type TableProps<T = unknown> = TableBase<T> & TableActions & PaginationSelectionCombination;
 
-export type Sortable = {
+export type Sortable<T> = {
   direction: Direction;
-  isSorted: (column: Column) => boolean;
+  isSorted: (column: Column<T>) => boolean;
   onClick: (
     event: React.MouseEvent<HTMLElement>,
-    column: Column,
-    callback: (event: React.MouseEvent<HTMLElement>, options: OnSortClickOptions) => void
+    column: Column<T>,
+    callback: (event: React.MouseEvent<HTMLElement>, options: OnSortClickOptions<T>) => void
   ) => void;
 };
 
-export type SortingState = {
+export type SortingState<T> = {
   direction: Direction;
-  column?: Column;
+  column?: Column<T>;
 };


### PR DESCRIPTION
## What did we change?

Changed the table to accept a generic

## Why are we doing this?

This will basically give any user using TS the ability to infer what is in each column. For example,

```ts
const items = [
  { name: 'Spiderman Triple-Action Web Blaster', price: '$2.99' },
  { name: "Thor's Hammer", price: '$6.99' },
] as const;

function MyTable() {
  return (
    <EzTable
      items={items}
      columns={[
        {
          heading: 'Name',
          component: ({ item: { name } }) => <Text>{name}</Text>
        },
        {
          heading: 'Price',
          component: ({ item: { price } }) => <Text>{price}</Text>
        }
      ]}
    />
  );
}
```

Now typescript will be aware that the type of `items` should infer in the `item` property of `columns.component`

## Screenshot(s) / Gif(s):

This is just DX

## Checklist

- [x] Provide test coverage for the changes made
- [ ] Update `src/unreleased.md` with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)