### PR TITLE
[DEVEX-1250] Fix code/preview toggle in doc-site for IE11

### DIFF
--- a/doc-site/src/components/Playground/Preview.js
+++ b/doc-site/src/components/Playground/Preview.js
@@ -131,7 +131,7 @@ const createPlayroomLink = code => {
   if (!code) return null;
 
   /* remove the react-router-dom imports */
-  const reactRouterDomImportRegex = /(?=const)(.*?)(?<=require\('react-router-dom'\)\;)/;
+  const reactRouterDomImportRegex = /(const)(.*?)(require\('react-router-dom'\)\;)/;
   const codeWithoutRouter = code.replace(reactRouterDomImportRegex, '');
 
   /* make the stateful code work in the playground with IIFE


### PR DESCRIPTION
## What did we change?
- Fixed the code/preview toggle in the doc-site for IE11.

## Why are we doing this?
- The toggle between preview and code in the doc-site wasn't working in IE11. I was getting an error about resources not found and not rendering react. Read a bunch about this issue people were having, seemed like their issues were related to gatsby cache...not our issue. Narrowed it down to the regex used to strip the `react-router-dom` imports in the playroom examples. Turns out javascript doesn't support regex lookbehinds yet.

## Screenshot(s) / Gif(s):
<img width="450" alt="Screen Shot 2021-06-03 at 10 38 38 AM" src="https://user-images.githubusercontent.com/3790037/120663809-5ceaf400-c458-11eb-9ff0-7451fd6bffb1.png">
<img width="445" alt="Screen Shot 2021-06-03 at 10 38 30 AM" src="https://user-images.githubusercontent.com/3790037/120663815-5fe5e480-c458-11eb-88f3-e3f4c4dd76a3.png">

## Checklist

- [ ] Provide test coverage for the changes made
- [ ] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)