### PR TITLE
Use stitches style insertion instead of snitches

### DIFF
--- a/doc-site/src/components/Playground/Preview.js
+++ b/doc-site/src/components/Playground/Preview.js
@@ -16,9 +16,9 @@ const codeIcon = (
     stroke="currentColor"
   >
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
       d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
     />
   </svg>
@@ -34,15 +34,15 @@ const previewIcon = (
     stroke="currentColor"
   >
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
       d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
     />
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
       d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
     />
   </svg>
@@ -58,15 +58,15 @@ const playIcon = (
     stroke="currentColor"
   >
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
       d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
     />
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
       d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
     />
   </svg>

--- a/jest.setup.tsx
+++ b/jest.setup.tsx
@@ -32,9 +32,9 @@ const GlobalStylesWrapper = ({children}) => (
     <Style ruleset={theme}>
       <Sprites />
       <EzGlobalStyles />
-      <VisualRegressionOverrides />
       {children}
     </Style>
+    <VisualRegressionOverrides />
   </>
 );
 

--- a/jest.setup.tsx
+++ b/jest.setup.tsx
@@ -3,7 +3,7 @@ import {toHaveNoViolations} from 'jest-axe';
 import {configure as configureSosia} from 'sosia';
 import {MarkdownSource} from 'sosia-markdown';
 import {RemotePuppeteerBrowserTarget} from 'sosia-remote-puppeteer';
-import Style from '@ezcater/snitches';
+import Style from './src/snitches';
 import EzGlobalStyles from './src/components/EzGlobalStyles';
 import theme from './src/components/theme.config';
 import {decorate as minifyDecorator} from './MinifiedBrowserTarget';

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, HTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './CloseButton.theme.config';
 
 const button = theme.css({

--- a/src/components/EzAlert/EzAlert.tsx
+++ b/src/components/EzAlert/EzAlert.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzAlert.theme.config';
 import EzTextStyle from '../EzTextStyle';
 import {ErrorIcon, InfoIcon, MarketingIcon, SuccessIcon, TipIcon, WarningIcon} from '../Icons';

--- a/src/components/EzAppLayout/EzAppLayout.tsx
+++ b/src/components/EzAppLayout/EzAppLayout.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, useContext} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzAppLayout.theme.config';
 import EzGlobalStyles from '../EzGlobalStyles';
 

--- a/src/components/EzBanner/EzBanner.tsx
+++ b/src/components/EzBanner/EzBanner.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzBanner.theme.config';
 import CloseButton from '../CloseButton';
 import EzHeading from '../EzHeading';

--- a/src/components/EzBaseFontSizeCompatibility/EzBaseFontSizeCompatibility.theme.config.ts
+++ b/src/components/EzBaseFontSizeCompatibility/EzBaseFontSizeCompatibility.theme.config.ts
@@ -1,0 +1,3 @@
+import {mergeCss} from '../theme.config';
+
+export default mergeCss({theme: {}});

--- a/src/components/EzBaseFontSizeCompatibility/EzBaseFontSizeCompatibility.tsx
+++ b/src/components/EzBaseFontSizeCompatibility/EzBaseFontSizeCompatibility.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import Style from '../../snitches';
+import theme from './EzBaseFontSizeCompatibility.theme.config';
+
+const styles = theme.global({':root': {'--recipe-base-font-size': '14px'}});
 
 const EzBaseFontSizeCompatibility = () => {
-  return <Style ruleset={':root {--recipe-base-font-size: 14px;}'} />;
+  styles();
+  return <Style ruleset={theme} />;
 };
 
 export default EzBaseFontSizeCompatibility;

--- a/src/components/EzBaseFontSizeCompatibility/EzBaseFontSizeCompatibility.tsx
+++ b/src/components/EzBaseFontSizeCompatibility/EzBaseFontSizeCompatibility.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 
 const EzBaseFontSizeCompatibility = () => {
   return <Style ruleset={':root {--recipe-base-font-size: 14px;}'} />;

--- a/src/components/EzBlankState/EzBlankState.tsx
+++ b/src/components/EzBlankState/EzBlankState.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import EzHeading from '../EzHeading';
 import EzTextStyle from '../EzTextStyle';
 import theme from './EzBlankState.theme.config';

--- a/src/components/EzButton/EzButton.tsx
+++ b/src/components/EzButton/EzButton.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzButton.theme.config';
 import EzTooltip from '../EzTooltip';
 import {domProps} from '../../utils';

--- a/src/components/EzCalendar/EzCalendar.tsx
+++ b/src/components/EzCalendar/EzCalendar.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, createRef, useState} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import dayjs from 'dayjs';
 import theme from './EzCalendar.theme.config';
 import EzButton from '../EzButton';

--- a/src/components/EzCard/EzCard.tsx
+++ b/src/components/EzCard/EzCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as CSS from 'csstype';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzCard.theme.config';
 import {
   grid,

--- a/src/components/EzCard/EzCardSection.tsx
+++ b/src/components/EzCard/EzCardSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzCard.theme.config';
 import EzCardHeading from './EzCardHeading';
 import {EzContent, EzHeader} from '../EzContent';

--- a/src/components/EzCarousel/EzCarousel.tsx
+++ b/src/components/EzCarousel/EzCarousel.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState, HTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzCarousel.theme.config';
 import {useUniqueId} from '../../utils/hooks';
 import {clsx, responsiveProps} from '../../utils';

--- a/src/components/EzCheckbox/EzCheckbox.tsx
+++ b/src/components/EzCheckbox/EzCheckbox.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzCheckbox.theme.config';
 import EzLabel from '../EzLabel';
 import {useUniqueId} from '../../utils/hooks';

--- a/src/components/EzField/EzChoice.tsx
+++ b/src/components/EzField/EzChoice.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzChoice.theme.config';
 import EzCheckbox from '../EzCheckbox';
 import EzRadioButton from '../EzRadioButton';

--- a/src/components/EzField/EzDateInput.tsx
+++ b/src/components/EzField/EzDateInput.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useRef} from 'react';
 import dayjs from 'dayjs';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import EzTextInput from './EzTextInput';
 import {TextInputWrapper} from './Picker.styles';

--- a/src/components/EzField/EzField.tsx
+++ b/src/components/EzField/EzField.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, CSSProperties} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import Label from '../EzLabel';
 import {InsetIcon, ErrorTriangle} from '../Icons';

--- a/src/components/EzField/EzListBox.tsx
+++ b/src/components/EzField/EzListBox.tsx
@@ -1,6 +1,6 @@
 import React, {useRef} from 'react';
 import Highlighter from 'react-highlight-words';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import {useUniqueId, useScrollIntoView} from '../../utils/hooks';
 import {clsx} from '../../utils';

--- a/src/components/EzField/EzSelect.tsx
+++ b/src/components/EzField/EzSelect.tsx
@@ -1,5 +1,5 @@
 import React, {useRef, useCallback} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import {TextInputWrapper} from './Picker.styles';
 import EzTextInput from './EzTextInput';

--- a/src/components/EzField/EzTextArea.tsx
+++ b/src/components/EzField/EzTextArea.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import EzTextInput from './EzTextInput';
 

--- a/src/components/EzField/EzTextInput.tsx
+++ b/src/components/EzField/EzTextInput.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import {domProps, filterValidProps} from '../../utils';
 

--- a/src/components/EzField/EzTimeInput.tsx
+++ b/src/components/EzField/EzTimeInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 import en from './en';
 import {useTranslation} from '../../utils/hooks';

--- a/src/components/EzField/Picker.styles.tsx
+++ b/src/components/EzField/Picker.styles.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzField.theme.config';
 
 const picker = theme.css({

--- a/src/components/EzFlashMessage/EzFlashMessage.tsx
+++ b/src/components/EzFlashMessage/EzFlashMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzFlashMessage.theme.config';
 import EzLayout from '../EzLayout';
 import EzHeading from '../EzHeading';

--- a/src/components/EzFormLayout/EzFormLayout.tsx
+++ b/src/components/EzFormLayout/EzFormLayout.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzFormLayout.theme.config';
 import {domProps} from '../../utils';
 

--- a/src/components/EzGlobalStyles/EzGlobalStyles.tsx
+++ b/src/components/EzGlobalStyles/EzGlobalStyles.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzGlobalStyles.theme.config';
 import features from './features';
 

--- a/src/components/EzHeading/EzHeading.tsx
+++ b/src/components/EzHeading/EzHeading.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, HTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzHeading.theme.config';
 import {ClearSlots, useSlotProps} from '../../utils/slots';
 import {domProps, mergeProps} from '../../utils';

--- a/src/components/EzInlineFeedback/EzInlineFeedback.tsx
+++ b/src/components/EzInlineFeedback/EzInlineFeedback.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, HTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzInlineFeedback.theme.config';
 import {ErrorIcon, ProgressIcon, SuccessIcon} from '../Icons';
 import en from './en';

--- a/src/components/EzLabel/EzLabel.tsx
+++ b/src/components/EzLabel/EzLabel.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, LabelHTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzLabel.theme.config';
 
 const styles = theme.css({

--- a/src/components/EzLayout/EzLayout.tsx
+++ b/src/components/EzLayout/EzLayout.tsx
@@ -1,5 +1,5 @@
 import React, {HTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzLayout.theme.config';
 import {domProps, responsiveProps} from '../../utils';
 

--- a/src/components/EzLink/EzLink.tsx
+++ b/src/components/EzLink/EzLink.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, ReactElement, ReactNode} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzLink.theme.config';
 import {Link as LinkProps} from './EzLink.types';
 import {isAnchor, isLink} from './utils';

--- a/src/components/EzModal/EzModal.tsx
+++ b/src/components/EzModal/EzModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzModal.theme.config';
 import EzButton from '../EzButton';
 import EzHeading from '../EzHeading';

--- a/src/components/EzNavigation/EzNavigation.tsx
+++ b/src/components/EzNavigation/EzNavigation.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, {FC, useState} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzNavigation.theme.config';
 import en from './en';
 import Logo, {LogoType} from './Logo';

--- a/src/components/EzNavigation/Hamburger.tsx
+++ b/src/components/EzNavigation/Hamburger.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzNavigation.theme.config';
 import {clsx} from '../../utils';
 

--- a/src/components/EzNavigation/Logo.tsx
+++ b/src/components/EzNavigation/Logo.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzNavigation.theme.config';
 import {Link} from '../EzLink/EzLink';
 import {LabelledLink, Link as LinkType} from '../EzLink/EzLink.types';

--- a/src/components/EzNavigation/Menu.tsx
+++ b/src/components/EzNavigation/Menu.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzNavigation.theme.config';
 import {Counter} from './Notifications';
 import {clsx} from '../../utils';

--- a/src/components/EzNavigation/Notifications.tsx
+++ b/src/components/EzNavigation/Notifications.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzNavigation.theme.config';
 
 const notification = theme.css({

--- a/src/components/EzNavigation/UserMenu.tsx
+++ b/src/components/EzNavigation/UserMenu.tsx
@@ -1,5 +1,5 @@
 import React, {useRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzNavigation.theme.config';
 import {useMenuTrigger, useMenuTriggerState} from '../Overlays';
 import EzLink from '../EzLink';

--- a/src/components/EzOrderSummary/EzOrderSummary.tsx
+++ b/src/components/EzOrderSummary/EzOrderSummary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import {EzCard, EzTable, EzTextStyle, EzLayout, EzCardSection} from '..';
 import en from './en';
 import {useTranslation} from '../../utils/hooks';

--- a/src/components/EzPage/EzPage.tsx
+++ b/src/components/EzPage/EzPage.tsx
@@ -1,5 +1,5 @@
 import React, {useRef, useContext} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzPage.theme.config';
 import {MaxWidth} from '../EzAppLayout/EzAppLayout';
 import EzHeading from '../EzHeading';

--- a/src/components/EzPage/EzPageSection.tsx
+++ b/src/components/EzPage/EzPageSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzPageSection.theme.config';
 import {usePageSection} from './EzPage';
 import {clsx} from '../../utils';

--- a/src/components/EzPageHeader/EzPageHeader.tsx
+++ b/src/components/EzPageHeader/EzPageHeader.tsx
@@ -1,5 +1,5 @@
 import React, {createRef, useRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import LinkButton from './LinkButton';
 import {Link, LabelledLink, Labelled} from '../EzLink/EzLink.types';
 import {EzHeading, EzLayout} from '..';

--- a/src/components/EzPageHeader/Tabs.tsx
+++ b/src/components/EzPageHeader/Tabs.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import {AnchorProps, LinkProps} from '../EzLink/EzLink.types';
 import LinkButton from './LinkButton';
 import theme from './Tabs.theme.config';

--- a/src/components/EzProgressTracker/EzProgressTracker.tsx
+++ b/src/components/EzProgressTracker/EzProgressTracker.tsx
@@ -1,5 +1,5 @@
 import React, {Fragment} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzProgressTracker.theme.config';
 import EzLayout from '../EzLayout';
 import EzTextStyle from '../EzTextStyle';

--- a/src/components/EzProvider/EzProvider.tsx
+++ b/src/components/EzProvider/EzProvider.tsx
@@ -1,6 +1,7 @@
 import React, {useContext, Ref, ReactNode} from 'react';
 import {Theme} from '@react-types/provider';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
+import topLevelTheme from '../theme.config';
 
 export interface ProviderProps {
   /** The content of the Provider. */
@@ -50,7 +51,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(
   const className = theme.global ? Object.values(theme.global).join(' ') : null;
 
   return (
-    <Style>
+    <Style ruleset={topLevelTheme}>
       <div className={className} ref={ref}>
         {children}
       </div>

--- a/src/components/EzProvider/EzProvider.tsx
+++ b/src/components/EzProvider/EzProvider.tsx
@@ -39,7 +39,11 @@ function Provider(props: ProviderProps, ref: Ref<HTMLDivElement>) {
       children
     );
 
-  return <Context.Provider value={context}>{contents}</Context.Provider>;
+  return (
+    <Style ruleset={topLevelTheme}>
+      <Context.Provider value={context}>{contents}</Context.Provider>
+    </Style>
+  );
 }
 
 const ProviderWrapper = React.forwardRef(function ProviderWrapper(
@@ -51,11 +55,9 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(
   const className = theme.global ? Object.values(theme.global).join(' ') : null;
 
   return (
-    <Style ruleset={topLevelTheme}>
-      <div className={className} ref={ref}>
-        {children}
-      </div>
-    </Style>
+    <div className={className} ref={ref}>
+      {children}
+    </div>
   );
 });
 

--- a/src/components/EzRadioButton/EzRadioButton.tsx
+++ b/src/components/EzRadioButton/EzRadioButton.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzRadioButton.theme.config';
 import {domProps} from '../../utils';
 

--- a/src/components/EzSearchInput/EzSearchInput.tsx
+++ b/src/components/EzSearchInput/EzSearchInput.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzSearchInput.theme.config';
 import EzTextInput from '../EzField/EzTextInput';
 

--- a/src/components/EzSegmentedControl/EzSegmentedControl.tsx
+++ b/src/components/EzSegmentedControl/EzSegmentedControl.tsx
@@ -1,5 +1,5 @@
 import React, {Fragment} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import Label from '../EzLabel';
 import theme from './EzSegmentedControl.theme.config';
 import {clsx} from '../../utils';

--- a/src/components/EzStatus/EzStatus.tsx
+++ b/src/components/EzStatus/EzStatus.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzStatus.theme.config';
 import {EzStatusProps} from './EzStatus.types';
 import {DotIcon} from '../Icons';

--- a/src/components/EzSuperRadioButtons/EzSuperRadioButtons.tsx
+++ b/src/components/EzSuperRadioButtons/EzSuperRadioButtons.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, Fragment} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzSuperRadioButtons.theme.config';
 import EzRadioButton from '../EzRadioButton';
 import {EzSuperRadioButtonsProps} from './EzSuperRadioButtons.types';

--- a/src/components/EzTable/EzTable.tsx
+++ b/src/components/EzTable/EzTable.tsx
@@ -1,5 +1,5 @@
 import React, {FC, createContext, createElement, useContext, useState, useEffect} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzTable.theme.config';
 import {EzCard} from '../EzCard';
 import EzCheckbox from '../EzCheckbox';

--- a/src/components/EzTable/TableCardSection.tsx
+++ b/src/components/EzTable/TableCardSection.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzTable.theme.config';
 import {EzCardSection} from '../EzCard';
 import {clsx} from '../../utils';

--- a/src/components/EzTextStyle/EzTextStyle.tsx
+++ b/src/components/EzTextStyle/EzTextStyle.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, AllHTMLAttributes} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzTextStyle.theme.config';
 
 const text = theme.css({

--- a/src/components/EzTimeline/EzTimeline.tsx
+++ b/src/components/EzTimeline/EzTimeline.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import {TimelineProps} from './EzTimeline.types';
 import theme from './EzTimeline.theme.config';
 import {clsx} from '../../utils';

--- a/src/components/EzTimeline/EzTimelineEvent.tsx
+++ b/src/components/EzTimeline/EzTimelineEvent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import {EzCard} from '../EzCard';
 import EzLayout from '../EzLayout';
 import EzHeading from '../EzHeading';

--- a/src/components/EzTimeline/EzTimelineIcon.tsx
+++ b/src/components/EzTimeline/EzTimelineIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzTimeline.theme.config';
 
 const styles = theme.css({

--- a/src/components/EzTimeline/EzTimelinePeriod.tsx
+++ b/src/components/EzTimeline/EzTimelinePeriod.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzTimeline.theme.config';
 
 const heading = theme.css({

--- a/src/components/EzToggle/EzToggle.tsx
+++ b/src/components/EzToggle/EzToggle.tsx
@@ -1,5 +1,5 @@
 import React, {forwardRef, useRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzToggle.theme.config';
 import EzLabel from '../EzLabel';
 import EzInlineFeedback from '../EzInlineFeedback';

--- a/src/components/EzTooltip/EzTooltip.tsx
+++ b/src/components/EzTooltip/EzTooltip.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useRef, ReactElement} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './EzTooltip.theme.config';
 import {useUniqueId} from '../../utils/hooks';
 import EzPopover from '../EzPopover';

--- a/src/components/Icons/index.tsx
+++ b/src/components/Icons/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './Icons.theme.config';
 import {clsx} from '../../utils';
 

--- a/src/components/theme.config.ts
+++ b/src/components/theme.config.ts
@@ -216,7 +216,20 @@ type MapUtils<U, T extends TTheme> = {
     : never;
 };
 
-const configs = [stitches] as any[];
+const getCustomProperties = theme => {
+  /** Object of custom property styles. */
+  const styles = {};
+
+  for (const scaleName in theme) {
+    for (const tokenName in theme[scaleName]) {
+      styles[`$${scaleName}-${tokenName}`] = String(
+        theme[scaleName][tokenName]
+      ).replace(/\$[$\w-]+/g, $1 => (/[^]\$/.test($1) ? $1 : `$${scaleName}${$1}`));
+    }
+  }
+
+  return styles;
+};
 
 /**
  * Extends the base stitches configuration with additional theme tokens.
@@ -237,20 +250,9 @@ export function mergeCss<
   Prefix,
   ThemeMap & BaseConfig['themeMap']
 > {
-  const utils = Object.assign({}, stitches.config.utils, extension.utils) as any;
-  const conditions = Object.assign({}, stitches.config.conditions, extension.conditions) as any;
-  const merged = createCss({
-    ...extension, 
-    utils, 
-    conditions,
-  });
+  const vars = getCustomProperties(extension.theme);
 
-  configs.push(merged);
+  stitches.global({':root': vars})();
 
-  return {
-    ...merged,
-    toString() {
-      return configs.map(config => config.toString()).join(' ');
-    },
-  } as any;
+  return stitches as any;
 }

--- a/src/components/theme.config.ts
+++ b/src/components/theme.config.ts
@@ -217,6 +217,8 @@ type MapUtils<U, T extends TTheme> = {
     : never;
 };
 
+const configs = [stitches] as any[];
+
 /**
  * Extends the base stitches configuration with additional theme tokens.
  */
@@ -245,10 +247,12 @@ export function mergeCss<
     insertMethod: () => () => {},
   });
 
+  configs.push(merged);
+
   return {
     ...merged,
     toString() {
-      return [stitches.toString(), merged.toString()].join(' ');
+      return configs.map(config => config.toString()).join(' ');
     },
   } as any;
 }

--- a/src/components/theme.config.ts
+++ b/src/components/theme.config.ts
@@ -202,7 +202,6 @@ const stitches = createCss({
     mediumToLarge: '@media (min-width: 768px) and (max-width: 1060.9375px)',
     large: '@media (min-width: 1061px)',
   },
-  insertMethod: () => () => {},
 });
 
 type BaseConfig = typeof stitches.config;
@@ -244,7 +243,6 @@ export function mergeCss<
     ...extension, 
     utils, 
     conditions,
-    insertMethod: () => () => {},
   });
 
   configs.push(merged);

--- a/src/snitches/index.tsx
+++ b/src/snitches/index.tsx
@@ -3,7 +3,7 @@ import React, {createContext, useContext} from 'react';
 
 const Context = createContext(null);
 
-const Style = ({children, ruleset}) => {
+const Style = ({children, ruleset}: any) => {
   const context = useContext(Context);
 
   if (context) return children;

--- a/src/snitches/index.tsx
+++ b/src/snitches/index.tsx
@@ -1,17 +1,25 @@
 /* eslint-disable filenames/match-exported */
 import React, {createContext, useContext} from 'react';
+// import ReactDOM from 'react-dom';
 
 const Context = createContext(null);
 
-const Style = ({children, ruleset}: any) => {
+const isNodeEnvironment = (): boolean => {
+  // https://nodejs.org/api/process.html#process_process_release
+  return typeof process !== 'undefined' && process?.release?.name === 'node';
+};
+
+const Tag = ({ruleset}) => <style dangerouslySetInnerHTML={{__html: ruleset?.toString() || ''}} />;
+
+const Style = ({children = null, ruleset}: any) => {
   const context = useContext(Context);
 
-  if (context) return children;
+  if (context || !isNodeEnvironment()) return children || null;
 
   return (
     <Context.Provider value>
       {children}
-      <style data-s-ssr dangerouslySetInnerHTML={{__html: ruleset?.toString() || ''}} />
+      <Tag ruleset={ruleset} />
     </Context.Provider>
   );
 };

--- a/src/snitches/index.tsx
+++ b/src/snitches/index.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable filenames/match-exported */
+import React, {createContext, useContext} from 'react';
+
+const Context = createContext(null);
+
+const Style = ({children, ruleset}) => {
+  const context = useContext(Context);
+
+  if (context) return children;
+
+  return (
+    <Context.Provider value>
+      {children}
+      <style data-s-ssr dangerouslySetInnerHTML={{__html: ruleset?.toString() || ''}} />
+    </Context.Provider>
+  );
+};
+
+export default Style;

--- a/templates/component/styled-component.hbs
+++ b/templates/component/styled-component.hbs
@@ -1,5 +1,5 @@
 import React, {forwardRef} from 'react';
-import Style from '@ezcater/snitches';
+import Style from '../../snitches';
 import theme from './{{ name }}.theme.config';
 
 const styles = theme.css({});


### PR DESCRIPTION
## What did we change?

- replaced `@ezcater/snitches` usage with a local version for easier iteration
- replaced `@ezcater/snitches` logic to only insert styles once for a context-tree
  - note: this is technically not a good option for streaming, since the styles can only be included once the whole react tree is rendered
- enabled stitches style insertion (removed the overridden `insertMethod` function)
- changed Recipe's theme usage such that there is only a single theme, instead of one-per-component
  -  this was needed as stitches native style insertion assumes a single theme, and will replace the `style[id=stitches]` element with the styles for a given theme when its styles are used
- fix: console warnings about `stroke-linecap` et al (using html attribute keys instead of react prop keys)
- Normalize snitches usage for EzBaseFontSizeCompatibility (to ensure it's styles would continue to be inserted correctly
- fix: ensure `EzProvider` is always a style provider (to make it easy for apps to have a top-level style provider)

## Why are we doing this?

- Cutting a version of Recipe for load testing to rule out whether using a snitches is causing a significant overhead during SSR

## Screenshot(s) / Gif(s):

## Checklist

- [ ] Provide test coverage for the changes made
- [ ] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)