### PR TITLE
[DF-29] Add edit (from github) button to doc-site

### DIFF
--- a/doc-site/src/components/EditDocsButton.js
+++ b/doc-site/src/components/EditDocsButton.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import {EzTooltip, EzLink} from '@ezcater/recipe';
+
+const EditDocsButton = ({path}) => {
+  if (!path || !path.fileAbsolutePath) {
+    return null;
+  }
+
+  const gitPath = path.fileAbsolutePath.split('/recipe/')[1];
+
+  const gitLink = `https://github.com/ezcater/recipe/edit/main/${gitPath}`;
+
+  return (
+    <EzTooltip message="Edit docs on GitHub">
+      <EzLink>
+        <a href={gitLink} target="_blank">
+          <svg
+            height="16"
+            fill="#8b99a6"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use xlinkHref="#editPencil" />
+          </svg>
+        </a>
+      </EzLink>
+    </EzTooltip>
+  );
+};
+
+export default EditDocsButton;

--- a/doc-site/src/components/Layout.js
+++ b/doc-site/src/components/Layout.js
@@ -27,6 +27,7 @@ import ComponentGrid from './ComponentGrid';
 import {SearchProvider} from '../providers/SearchProvider';
 import TableOfContents from './TableOfContents';
 import Sprites from './Sprites';
+import EditDocsButton from './EditDocsButton';
 
 const Layout = ({
   name,
@@ -64,6 +65,10 @@ const Layout = ({
       const topLevel = pages
         .filter(p => Boolean(p.frontmatter.order))
         .sort((a, b) => a.frontmatter.order - b.frontmatter.order);
+
+      const absolutePath = pages.find(
+        page => page.frontmatter.path === path || page.frontmatter.path === `${path}/`
+      );
 
       const links = topLevel.map(page => ({
         to: page.frontmatter.path,
@@ -182,9 +187,17 @@ const Layout = ({
                             <ComponentGrid />
                           ) : (
                             children ||
-                            sections.map((section, i) => (
-                              <EzCardSection key={i}>{section}</EzCardSection>
-                            ))
+                            sections.map((section, i) => {
+                              const actions = {
+                                title: 'Overview',
+                                actions: <EditDocsButton path={absolutePath} />,
+                              };
+                              return (
+                                <EzCardSection key={i} {...(i === 0 ? actions : {})}>
+                                  {section}
+                                </EzCardSection>
+                              );
+                            })
                           )}
                         </EzCard>
                       </EzPageSection>

--- a/doc-site/src/components/Sprites.js
+++ b/doc-site/src/components/Sprites.js
@@ -5,6 +5,19 @@ import React from 'react';
   if you add/remove/edit anything here, edit it in src/components/Sprites too
 */
 
+const editPencil = (
+  <svg
+    id="editPencil"
+    height="16"
+    fill="#8b99a6"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z" />
+  </svg>
+);
+
 const phone = (
   <svg id="phone" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
@@ -61,6 +74,7 @@ const fiveStarRating = (
 const Sprites = () => {
   return (
     <div style={{display: 'none'}}>
+      {editPencil}
       {phone}
       {chatBubble}
       {receipt}

--- a/src/components/Sprites.js
+++ b/src/components/Sprites.js
@@ -5,6 +5,19 @@ import React from 'react';
   if you add/remove/edit anything here, edit it in /doc-site/src/components/Sprites too
 */
 
+const editPencil = (
+  <svg
+    id="editPencil"
+    height="16"
+    fill="#8b99a6"
+    viewBox="0 0 16 16"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z" />
+  </svg>
+);
+
 const phone = (
   <svg id="phone" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
@@ -61,6 +74,7 @@ const fiveStarRating = (
 const Sprites = () => {
   return (
     <div style={{display: 'none'}}>
+      {editPencil}
       {phone}
       {chatBubble}
       {receipt}


### PR DESCRIPTION
## What did we change?
- Add an "Edit" button to edit docs from github

## Why are we doing this?
- Encourage users to suggest edits to the doc-site

## Screenshot(s) / Gif(s):
<img width="1191" alt="Screen Shot 2021-08-03 at 4 58 54 PM" src="https://user-images.githubusercontent.com/3790037/128086815-4c22ddb9-192b-419c-8f8c-e4d801d3fe6b.png">

<img width="1194" alt="Screen Shot 2021-08-03 at 4 59 09 PM" src="https://user-images.githubusercontent.com/3790037/128086821-fb1785d7-8887-4694-8606-f326b1ac2d01.png">

<img width="311" alt="Screen Shot 2021-08-03 at 5 00 34 PM" src="https://user-images.githubusercontent.com/3790037/128086822-d8be8a2e-6063-4cbb-a5b7-3c1eb2b74427.png">


## Checklist

- [ ] Provide test coverage for the changes made
- [ ] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)