### PR TITLE
[DF-63] Add display names to components

### DIFF
--- a/.changeset/tidy-spies-cover.md
+++ b/.changeset/tidy-spies-cover.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+workflow: export default for anonymous functions to improve debugging

--- a/src/components/EzCard/EzCardHeading.tsx
+++ b/src/components/EzCard/EzCardHeading.tsx
@@ -39,6 +39,6 @@ const EzCardHeading: React.FC<HeadingProps> = ({title, subtitle, actions}) => {
   return <div className={box()}>{actions ? layout : heading}</div>;
 };
 
-EzCardHeading.displayName = 'EzCard';
+EzCardHeading.displayName = 'EzCardHeading';
 
 export default EzCardHeading;

--- a/src/components/EzField/EzChoice.tsx
+++ b/src/components/EzField/EzChoice.tsx
@@ -79,7 +79,7 @@ const Option = ({input, bordered, disabled, rendered}) => {
   );
 };
 
-export default props => {
+const EzChoice = props => {
   const {
     type,
     name: fieldName,
@@ -155,3 +155,5 @@ export default props => {
     </Style>
   );
 };
+
+export default EzChoice;

--- a/src/components/EzField/EzTextArea.tsx
+++ b/src/components/EzField/EzTextArea.tsx
@@ -23,8 +23,10 @@ const textArea = theme.css({
   },
 });
 
-export default React.forwardRef<HTMLTextAreaElement, {size}>(({size, ...rest}, ref) => (
+const EzTextArea = React.forwardRef<HTMLTextAreaElement, {size}>(({size, ...rest}, ref) => (
   <Style ruleset={theme}>
     <EzTextInput ref={ref} {...rest} multiLine rows={rows(size)} className={textArea()} />
   </Style>
 ));
+
+export default EzTextArea;

--- a/src/components/EzField/EzTimeInput.tsx
+++ b/src/components/EzField/EzTimeInput.tsx
@@ -29,7 +29,7 @@ const layout = theme.css({
   input: {paddingLeft: '2.5em'},
 });
 
-export default ({start, end, step = 60, value, ...rest}) => {
+const EzTimeInput = ({start, end, step = 60, value, ...rest}) => {
   const {t} = useTranslation(en);
 
   const date = dayjs().format(t('DATE_FORMAT'));
@@ -62,3 +62,5 @@ export default ({start, end, step = 60, value, ...rest}) => {
     </Style>
   );
 };
+
+export default EzTimeInput;


### PR DESCRIPTION
## What did we change?
- Added display names to `Ez-` components

## Why are we doing this?
- Assist with debugging, closes https://github.com/ezcater/recipe/issues/196

## Screenshot(s) / Gif(s):

## Checklist

- [ ] Provide test coverage for the changes made
- [x] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)