### PR TITLE
[DF-67] Add aria-invalid and aria-describedby to EzField

### DIFF
--- a/.changeset/dull-tools-happen.md
+++ b/.changeset/dull-tools-happen.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+test: add tests for aria-invalid and aria-describedby on EzField

--- a/.changeset/funny-cougars-laugh.md
+++ b/.changeset/funny-cougars-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+deps: update @testing-library/jest-dom

--- a/.changeset/great-dingos-film.md
+++ b/.changeset/great-dingos-film.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+feat: add aria-invalid and aria-describedBy to EzField

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezcater/recipe",
-  "version": "12.0.5",
+  "version": "12.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15036,9 +15036,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.3.tgz",
-      "integrity": "sha512-vP8ABJt4+YIzu9UItbpJ6nM5zN3g9/tpLcp2DJiXyfX9gnwgcmLsa42+YiohNGEtSUTsseb6xB9HAwlgk8WdaQ==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz",
+      "integrity": "sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -15047,40 +15047,17 @@
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
-        "jest-diff": "^25.1.0",
-        "jest-matcher-utils": "^25.1.0",
+        "dom-accessibility-api": "^0.5.6",
         "lodash": "^4.17.15",
         "redent": "^3.0.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -15109,21 +15086,10 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "css": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "source-map": "^0.6.1",
-            "source-map-resolve": "^0.6.0"
-          }
-        },
-        "diff-sequences": {
-          "version": "25.2.6",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
-          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+        "dom-accessibility-api": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz",
+          "integrity": "sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==",
           "dev": true
         },
         "has-flag": {
@@ -15132,68 +15098,10 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "jest-diff": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
-          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
-          "dev": true,
-          "requires": {
-            "chalk": "^3.0.0",
-            "diff-sequences": "^25.2.6",
-            "jest-get-type": "^25.2.6",
-            "pretty-format": "^25.5.0"
-          }
-        },
-        "jest-get-type": {
-          "version": "25.2.6",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
-          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
-          "dev": true
-        },
-        "jest-matcher-utils": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
-          "integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^3.0.0",
-            "jest-diff": "^25.5.0",
-            "jest-get-type": "^25.2.6",
-            "pretty-format": "^25.5.0"
-          }
-        },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-          "dev": true,
-          "requires": {
-            "atob": "^2.1.2",
-            "decode-uri-component": "^0.2.0"
-          }
-        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -15732,9 +15640,9 @@
       }
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz",
-      "integrity": "sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.1.tgz",
+      "integrity": "sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
@@ -19479,6 +19387,35 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
       }
     },
     "css-color-names": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@storybook/addon-links": "^6.1.6",
     "@storybook/react": "^6.2.9",
     "@testing-library/dom": "^7.22.1",
-    "@testing-library/jest-dom": "^5.11.3",
+    "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^10.4.7",
     "@testing-library/user-event": "^12.1.0",
     "@types/cheerio": "^0.22.15",

--- a/src/components/EzField/EzField.tsx
+++ b/src/components/EzField/EzField.tsx
@@ -145,9 +145,14 @@ const EzField = forwardRef<HTMLElement, Props>((props, ref) => {
   const active = focused || hovered;
   const showError = Boolean(touched && error);
   const labelType = isChoiceElement ? 'div' : 'label';
+  const errorMessageId = `errorMessage-${id}`;
+  const helperTextId = `helperText-${id}`;
   const errorMessage = (
     <div className={errorContainer()}>
-      <span className={clsx(errorCallout({active, inline: showInlineError}), arrow())}>
+      <span
+        id={errorMessageId}
+        className={clsx(errorCallout({active, inline: showInlineError}), arrow())}
+      >
         {error}
       </span>
     </div>
@@ -182,7 +187,11 @@ const EzField = forwardRef<HTMLElement, Props>((props, ref) => {
             {!showInlineError && showError && errorMessage}
           </div>
         )}
-        {helperText && <div className={helper()}>{helperText}</div>}
+        {helperText && (
+          <div id={helperTextId} className={helper()}>
+            {helperText}
+          </div>
+        )}
         <div>
           <div style={relative}>
             <Input
@@ -192,6 +201,8 @@ const EzField = forwardRef<HTMLElement, Props>((props, ref) => {
                 id,
                 name: props.name || id,
                 'aria-labelledby': labelId,
+                'aria-invalid': showError,
+                'aria-describedby': clsx(showError && errorMessageId, helperText && helperTextId),
                 ref,
                 showInlineError: (showInlineError && showError) || undefined,
               }}

--- a/src/components/EzField/__tests__/EzField.test.tsx
+++ b/src/components/EzField/__tests__/EzField.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {visualSnapshots} from 'sosia';
 import {axe} from 'jest-axe';
 import {render, getByLabelText, fireEvent, act, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
 import regressionTests from './EzField.test.md';
 import markdown from '../EzField.md';
 import EzField from '../EzField';
@@ -132,6 +133,32 @@ describe('EzField', () => {
     const {container} = render(<EzField label="Basic text" />);
     const actual = await axe(container.outerHTML);
     expect(actual).toHaveNoViolations();
+  });
+
+  it('should have correct aria-invalid and aria-describedby values with error state', async () => {
+    const helperText = 'Provide a name';
+    const errorMessage = 'Name too short';
+    const id = '1';
+    const labelText = 'Name';
+    const {container} = render(
+      <EzField label={labelText} id={id} touched error={errorMessage} helperText={helperText} />
+    );
+
+    const input = getByLabelText(container, labelText);
+    expect(input).toBeInvalid();
+    const accessibleDescription = `${errorMessage} ${helperText}`;
+    expect(input).toHaveAccessibleDescription(accessibleDescription);
+  });
+
+  it('should have correct aria-invalid and aria-describedby values without error state', async () => {
+    const helperText = 'Provide a name';
+    const id = '1';
+    const labelText = 'Name';
+    const {container} = render(<EzField label={labelText} id={id} helperText={helperText} />);
+
+    const input = getByLabelText(container, labelText);
+    expect(input).toBeValid();
+    expect(input).toHaveAccessibleDescription(helperText);
   });
 
   it('should pass type checking', () => {


### PR DESCRIPTION
## What did we change?
- Added aria-invalid and aria-describedBy to EzField

## Why are we doing this?
- Improve accessibility
- Improve testing
- Closes https://github.com/ezcater/recipe/issues/671

## Screenshot(s) / Gif(s):

<img width="923" alt="Screen Shot 2021-08-06 at 11 20 50 AM" src="https://user-images.githubusercontent.com/3790037/128533837-ec42c5b8-35de-4f42-91c7-89d3782c553e.png">

<img width="874" alt="Screen Shot 2021-08-06 at 11 21 37 AM" src="https://user-images.githubusercontent.com/3790037/128533841-bc57bc3a-8b24-4db5-97f2-bd9c32d3d764.png">

## Checklist

- [x] Provide test coverage for the changes made
- [x] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)