### PR TITLE
Remove symbol polyfill, bump snitches

### DIFF
--- a/.changeset/breezy-candles-mix.md
+++ b/.changeset/breezy-candles-mix.md
@@ -1,0 +1,6 @@
+---
+'@ezcater/recipe': minor
+---
+
+- deps: upgraded `@ezcater/snitches` to fix an issue with SVG style hydration
+- fix: removed the custom `Symbol` polyfill in favor of relying on the consuming application to supply it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezcater/recipe",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5473,17 +5473,17 @@
       "dev": true
     },
     "@ezcater/snitches": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@ezcater/snitches/-/snitches-0.2.7.tgz",
-      "integrity": "sha512-J8lqf8gSJ1gJAnUMUiPTZPlD+qe4mlOL4c8tGyB4aM8zvhDJ+oZW3INuVRex5tzu2wyzmk/YrO30xWvUYZYMJg==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@ezcater/snitches/-/snitches-0.2.8.tgz",
+      "integrity": "sha512-WfGz5Fq9kYDkza8VFM5t/cyH5jfuT0fbFu2rTr30i7qr+GU905pwfYaGSNkg+hnKcIm9mBupIfdjvEMYUPUXlg==",
       "requires": {
         "csstype": "^3.0.6"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+          "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^0.7.3",
-    "@ezcater/snitches": "^0.2.7",
+    "@ezcater/snitches": "^0.2.8",
     "@popperjs/core": "^2.1.1",
     "@react-stately/collections": "^3.3.2",
     "@react-stately/list": "^3.2.3",

--- a/packages/@stitches/core/dist/index.js
+++ b/packages/@stitches/core/dist/index.js
@@ -1,14 +1,6 @@
-if (typeof globalThis === 'undefined') window.globalThis = window;
-
-const isIE11 = typeof window !== `undefined` && !!window.MSInputMethodContext;
-const Symbol = isIE11
-  ? {
-      for(x) {
-        return x;
-      },
-      iterator: '__symbol:iterator0.97589819915729773',
-    }
-  : globalThis.Symbol;
+if (typeof globalThis === 'undefined' && typeof window !== 'undefined') {
+  window.globalThis = window;
+}
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }

--- a/packages/@stitches/core/src/polyfills.js
+++ b/packages/@stitches/core/src/polyfills.js
@@ -1,11 +1,3 @@
-if (typeof globalThis === 'undefined') window.globalThis = window;
-
-const isIE11 = typeof window !== `undefined` && !!window.MSInputMethodContext;
-const Symbol = isIE11
-  ? {
-      for(x) {
-        return x;
-      },
-      iterator: '__symbol:iterator0.97589819915729773',
-    }
-  : globalThis.Symbol;
+if (typeof globalThis === 'undefined' && typeof window !== 'undefined') {
+  window.globalThis = window;
+}


### PR DESCRIPTION
## What did we change?

* Upgrade @ezcater/snitches to fix an issue with SVG style hydration
* Remove the custom Symbol polyfill in favor of relying on the consuming application to supply it

## Why are we doing this?

Bug fixes that came up when testing store-next and ezmanage against recipe 12

## Checklist

- [ ] Provide test coverage for the changes made
- [x] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)