### PR TITLE
Fix AutoSuggest/ComboBox onBlur bug

### DIFF
--- a/.changeset/neat-dodos-applaud.md
+++ b/.changeset/neat-dodos-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+Fix: AutoSuggest onBlur bug when clicking item within filtered collection

--- a/src/components/EzField/useComboBox.ts
+++ b/src/components/EzField/useComboBox.ts
@@ -89,8 +89,8 @@ export function useComboBox(props, state): ComboBoxAria {
     // call the user defined onBlur (if provided)
     props.onBlur?.(e);
 
-    // clear the input if no value was selected
-    if (selectionManager.selectedKey === null) state.setInputValue('');
+    // clear the input if no value was selected, and the popover is closing
+    if (selectionManager.selectedKey === null && props.popoverRef.current === null) state.setInputValue('');
   };
 
   const focusedKeyId = getItemId(menuProps.id, selectionManager.focusedKey);


### PR DESCRIPTION
When a `mouseDown` occurs within a filtered results list, the ComboBox `onBlur` event is fired, triggering a render, before a `onClick` can be registered. This change checks if the popover is still present to determine if the `onBlur` happens inside or outside of the list box.

Fixes #713 

## Screenshot(s) / Gif(s):

https://user-images.githubusercontent.com/3891632/146647545-e2a6eaf8-519a-4b19-9045-994c6cf50528.mov