### PR TITLE
fix: removed "require" function, a webpack protected word which was preventing loading of the doc site

### DIFF
--- a/.changeset/fuzzy-feet-shop.md
+++ b/.changeset/fuzzy-feet-shop.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: removed "require" function, a protected word in node 14 which was preventing loading of the doc site

--- a/.changeset/fuzzy-feet-shop.md
+++ b/.changeset/fuzzy-feet-shop.md
@@ -2,4 +2,4 @@
 '@ezcater/recipe': patch
 ---
 
-fix: removed "require" function, a protected word in node 14 which was preventing loading of the doc site
+fix: removed "require" function, a webpack protected word which was preventing loading of the doc site

--- a/doc-site/src/components/Markdown.js
+++ b/doc-site/src/components/Markdown.js
@@ -30,8 +30,10 @@ const cleanProps = p =>
 
 const HtmlAst = ({htmlAst, scope}) => {
   // ignore the style tag, as HTML ast gives us a string, but react expects a style object
-  const heading = (size, as) => ({style, ...props}) =>
-    React.createElement(Components.EzHeading, {size, as, className: 'gatsby', ...props});
+  const heading =
+    (size, as) =>
+    ({style, ...props}) =>
+      React.createElement(Components.EzHeading, {size, as, className: 'gatsby', ...props});
 
   const wrapEl = type => props => React.createElement(type, {className: 'gatsby', ...props});
 
@@ -85,30 +87,28 @@ const HtmlAst = ({htmlAst, scope}) => {
   return htmlAst.children.map(renderTag);
 };
 
-const require = () => ({
-  Link,
-  NavLink,
-  BrowserRouter:
-    typeof window === 'undefined'
-      ? ({children}) => React.createElement(StaticRouter, {context: {}, location: '/', children})
-      : BrowserRouter,
-  Route,
-  faCoffee,
-  emptyStar,
-  halfStar,
-  fullStar,
-  Pizza,
-  Fries,
-  Ramen,
-});
-
 const ezCaterLogoPath = logo;
 const scope = {
   ...Components,
   styled,
   css,
   Global,
-  require,
+  require: () => ({
+    Link,
+    NavLink,
+    BrowserRouter:
+      typeof window === 'undefined'
+        ? ({children}) => React.createElement(StaticRouter, {context: {}, location: '/', children})
+        : BrowserRouter,
+    Route,
+    faCoffee,
+    emptyStar,
+    halfStar,
+    fullStar,
+    Pizza,
+    Fries,
+    Ramen,
+  }),
   ezCaterLogoPath,
   withPrefix,
   Placeholder,


### PR DESCRIPTION
## What did we change?

This PR moves the `require` function directly into the scope that uses it so as not to redefine the protected `require` word.

## Why are we doing this?

Recipe now uses node version `14.18.3`, which has various key/protected words like `require`. We were redefining `require` in the doc site, creating an error in development and preventing the site from loading. 

## Checklist

- [x] Create a changeset (`npm run changeset`) with a summary of the changes

[Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)