### PR TITLE
fix: removed duplicate snapshot test

### DIFF
--- a/.changeset/empty-cherries-punch.md
+++ b/.changeset/empty-cherries-punch.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: removed duplicate snapshot test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezcater/recipe",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/EzPage/__tests__/EzPage.test.md
+++ b/src/components/EzPage/__tests__/EzPage.test.md
@@ -97,11 +97,3 @@
   </EzPage>
 </Media>
 ```
-
-### Has white background when optional backgroundColor prop is passed in with "white" as value
-
-```jsx
-<EzPage backgroundColor="white">
-  <EzCard title="Card">The background behind this card should be white</EzCard>
-</EzPage>
-```


### PR DESCRIPTION
## What did we change?

Removed a manual visual snapshot test. Also `package-lock.json` version updated to 13.0.2, which didn't get bumped for some reason after the last version package release.

## Why are we doing this?

The test was already covered from the doc-site.

## Checklist

- [x] Create a changeset (`npm run changeset`) with a summary of the changes