### PR TITLE
Update PR template to include checklist for moving components to Storybook Docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/storybook_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/storybook_template.md
@@ -1,0 +1,38 @@
+## What did we change?
+
+## Why are we doing this?
+
+This is part of an effort to switch our doc site from Gatbsy to Storybook Docs.
+
+_Note: This is an internal documentation change that doesn't affect the recipe core library and therefore has no changeset._
+
+## Screenshot(s) / Gif(s):
+
+## Checklist
+
+- [ ] Create new file: `src/components/EzComponent/Documentation/EzComponent.mdx` and populate from Gastby `.md` file.
+- [ ] Create new file for default story: `src/components/EzComponent/Documentation/Stories/Default.stories.tsx`
+- [ ] Create any remaining stories grouped as needed: `src/components/EzComponent/Documentation/Stories/Example1Stories.stories.tsx`
+- [ ] Create snapshot: `src/components/EzComponent/Documentation/EzComponent.snapshot.tsx`
+- [ ] Add any regression tests as a story: `src/components/EzComponent/Documentation/Stories/Regression.stories.tsx`
+- [ ] Move (or create) `EzComponent.snippets.tsx` into Documentation folder and make sure snippet matches default story
+- [ ] Delete old Gatsby files:
+  - `src/components/EzComponent/EzComponent.md`
+  - `src/components/EzComponent/EzComponent.preview.md`
+  - `src/components/EzComponent/__tests__/EzComponent.test.md`
+- [ ] Test all the things:
+  - [ ] All control props work as expected
+  - [ ] All "Show Code" displays correctly
+  - [ ] Playroom works for docs and all stories
+  - [ ] All action and interaction tests pass for all stories
+  - [ ] Regression stories only show up in development mode: `STORYBOOK_INCLUDE_REGRESSION_STORIES=1 yarn storybook`
+  - [ ] Component library preview and link works
+  - [ ] Related component links work (if already in Storybook Docs)
+  - [ ] Add any changesets (only if there are recipe library changes)
+  - [ ] Git commits are organized
+  - [ ] `yarn lint` passes
+  - [ ] `yarn type-check` passes
+  - [ ] `yarn test` passes
+  - [ ] All chromatic tests pass/approved
+
+  [Templates](https://github.com/ezcater/recipe/discussions/940)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+Please use the default template below, or choose an appropriate sub-template by going to the `Preview` tab and selecting one of the following:
+* [Storybook Docs](?template=storybook_template.md)
+
 ## What did we change?
 
 ## Why are we doing this?
@@ -8,5 +11,5 @@
 
 - [ ] Provide test coverage for the changes made
 - [ ] Create a changeset (`yarn changeset`) with a summary of the changes
-
+ 
 [Contributing guidelines](https://ezcater.github.io/recipe/guides/contributing/)


### PR DESCRIPTION
## What did we change?
- Adds a template subdirectory to use multiple PR templates.
- Adds a new PR template for moving components to storybook docs. This should be removed once all components have been moved over.

## Why are we doing this?
This will help to ensure all steps in our [checklist](https://github.com/ezcater/recipe/discussions/940) are completed before a PR is opened.

_Note: No Changeset is included as this change does not affect the Recipe library._

## Screenshot(s) / Gif(s):
Default template:
<img width="917" alt="Screenshot 2023-05-30 at 2 32 11 PM" src="https://github.com/ezcater/recipe/assets/5418735/37186126-9ae0-48b4-b562-a41136211df5">
Storybook docs template:
<img width="1074" alt="Screenshot 2023-05-30 at 1 27 25 PM" src="https://github.com/ezcater/recipe/assets/5418735/1473517d-1687-4403-9f0b-270cca5f1cdf">
