### PR TITLE
fix: switch table sort icons for asc and desc directions

### DIFF
--- a/.changeset/tiny-pianos-fry.md
+++ b/.changeset/tiny-pianos-fry.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: switch table sort icons for asc and desc directions

--- a/packages/recipe/src/components/EzTable/EzTable.tsx
+++ b/packages/recipe/src/components/EzTable/EzTable.tsx
@@ -203,7 +203,7 @@ const TableContext = createContext(null);
 const SortIcon = ({direction, isSorted}) => (
   <Box fontSize="0.6rem">
     <EzIcon
-      icon={isSorted ? (direction === 'asc' ? faSortDown : faSortUp) : faSort}
+      icon={isSorted ? (direction === 'asc' ? faSortUp : faSortDown) : faSort}
       size="inherit"
     />
   </Box>


### PR DESCRIPTION
## What did we change?

- [fix: switch table sort icons for asc and desc directions](https://github.com/ezcater/recipe/commit/7d5134313c6af370ffc8f4fcd039b93cc5a6a11a)

## Why are we doing this?
The icons directions were mistakenly flipped. This PR fixes that.

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes