### PR TITLE
Make EzSearchInput `type="search"` to make clearable by default

### DIFF
--- a/.changeset/cuddly-ducks-cry.md
+++ b/.changeset/cuddly-ducks-cry.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: make EzSearchInput type search to make clearable by default

--- a/packages/recipe/src/components/EzSearchInput/EzSearchInput.tsx
+++ b/packages/recipe/src/components/EzSearchInput/EzSearchInput.tsx
@@ -9,12 +9,13 @@ const searchInput = theme.css({
   '&&': {
     paddingLeft: '$search-input-padding-left',
   },
+  WebkitAppearance: 'none',
 });
 
 type Props = React.InputHTMLAttributes<HTMLInputElement>;
 
 const EzSearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => (
-  <EzTextInput ref={ref} {...props} className={searchInput()} />
+  <EzTextInput ref={ref} {...props} className={searchInput()} type="search" />
 ));
 
 export default EzSearchInput;


### PR DESCRIPTION
## What did we change?
- [make EzSearchInput type search to make clearable by default](https://github.com/ezcater/recipe/commit/9865122004bffe38775565514335cf0e3629d8ce)

## Why are we doing this?

Design [request](https://www.figma.com/file/3T0PuTpgMT2pE5HnbLE4Xp/Corporate-Dashboard?node-id=4665%3A12013&mode=dev) - this PR adds the clearable functionality by default - style of icon cannot be easily changed, so confirmed with design that this will do until this component is redesigned.

## Screenshot(s) / Gif(s):
<img width="654" alt="Screenshot 2023-06-29 at 4 45 34 PM" src="https://github.com/ezcater/recipe/assets/5418735/56cdb0d1-3d73-47a1-9731-86cedf797160">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes