### PR TITLE
adding noopener noreferrer to link that opens new tab

### DIFF
--- a/docs/src/components/EditDocsButton.js
+++ b/docs/src/components/EditDocsButton.js
@@ -13,7 +13,7 @@ const EditDocsButton = ({path}) => {
   return (
     <EzTooltip message="Edit docs on GitHub">
       <EzLink>
-        <a href={gitLink} target="_blank">
+        <a href={gitLink} target="_blank" rel="noopener noreferrer">
           <svg
             height="16"
             fill="#8b99a6"


### PR DESCRIPTION
Please use the default template below, or choose an appropriate sub-template by going to the `Preview` tab and selecting one of the following:
* [Storybook Docs](?template=storybook_template.md)

## What did we change?

## Why are we doing this?

https://ezcater.atlassian.net/browse/SEC-3869

resolves:

https://github.com/ezcater/recipe/security/code-scanning/1