### PR TITLE
Disable the emotion babel plugin until we remove stitches

### DIFF
--- a/.changeset/spotty-emus-deny.md
+++ b/.changeset/spotty-emus-deny.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: prevent the emotion plugin from rewriting stitches css prop

--- a/packages/recipe/babel.config.js
+++ b/packages/recipe/babel.config.js
@@ -1,6 +1,6 @@
-const isStorybookCommand = () =>
-  process.env.npm_lifecycle_event === 'storybook' ||
-  process.env.npm_lifecycle_event === 'build-storybook';
+// const isStorybookCommand = () =>
+//   process.env.npm_lifecycle_event === 'storybook' ||
+//   process.env.npm_lifecycle_event === 'build-storybook';
 
 module.exports = api => {
   api.cache(true);
@@ -10,25 +10,26 @@ module.exports = api => {
     plugins: [
       '@babel/plugin-transform-runtime',
       'babel-plugin-dev-expression',
-      !isStorybookCommand() && [
-        '@emotion',
-        {
-          importMap: {
-            '@mui/system': {
-              styled: {
-                canonicalImport: ['@emotion/styled', 'default'],
-                styledBaseImport: ['@mui/system', 'styled'],
-              },
-            },
-            '@mui/material/styles': {
-              styled: {
-                canonicalImport: ['@emotion/styled', 'default'],
-                styledBaseImport: ['@mui/material/styles', 'styled'],
-              },
-            },
-          },
-        },
-      ],
+      // TODO: uncoment when stitches has been removed from recipe
+      // !isStorybookCommand() && [
+      //   '@emotion',
+      //   {
+      //     importMap: {
+      //       '@mui/system': {
+      //         styled: {
+      //           canonicalImport: ['@emotion/styled', 'default'],
+      //           styledBaseImport: ['@mui/system', 'styled'],
+      //         },
+      //       },
+      //       '@mui/material/styles': {
+      //         styled: {
+      //           canonicalImport: ['@emotion/styled', 'default'],
+      //           styledBaseImport: ['@mui/material/styles', 'styled'],
+      //         },
+      //       },
+      //     },
+      //   },
+      // ],
     ].filter(Boolean),
     env: {
       esm: {


### PR DESCRIPTION
## What did we change?

This temporarily comments out the `@emotion/babel-plugin` from the recipe babel config

## Why are we doing this?

I added this babel plugin when I rewrote EzAlert to use MUI+emotion (https://github.com/ezcater/recipe/pull/1005). This plugin enables some build-time optimizations for emotion (as well as enabling component css nesting), but it also rewrites all `css={}` props at build time. Both emotion and stitches use this special css prop, and the emotion plugin was accidentally overwriting the stitches calls and passing in invalid objects for stitches.

There is no way for it to be able to tell what is stitches and what is emotion, so the simplest fix is to just remove it for now. I chose to leave it commented out rather than removing it so we can easily enable it once we're done migrating fully away from stitches

## Screenshot(s) / Gif(s):

Before (notice on line 35 we're passing in the emotion object created on line 11 to the `css` prop):

<img width="899" alt="Screenshot 2023-08-25 at 11 52 34 AM" src="https://github.com/ezcater/recipe/assets/1180841/97a08749-1d7f-4044-8dfd-831e6e0955f6">

After (notice that on line 22-25 we're now passing in a plain JS object for the `css` prop):

<img width="899" alt="Screenshot 2023-08-25 at 11 52 54 AM" src="https://github.com/ezcater/recipe/assets/1180841/a0e0c50e-253a-480d-91df-b061ef004d5f">

## Checklist

- [ ] Provide test coverage for the changes made
- [x] Create a changeset (`yarn changeset`) with a summary of the changes
 
[Contributing guidelines](https://recipe.ezcater.com/?path=/docs/guides-contributing--docs)