### PR TITLE
Make Recipe compatible with React 18 types [FEC-805]

### DIFF
--- a/.changeset/three-donuts-eat.md
+++ b/.changeset/three-donuts-eat.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: support React 18 types

--- a/packages/recipe/src/components/EzAppLayout/EzAppLayout.tsx
+++ b/packages/recipe/src/components/EzAppLayout/EzAppLayout.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, useContext} from 'react';
+import React, {FC, createContext, type PropsWithChildren, useContext} from 'react';
 import {VariantProps} from '@stitches/core';
 import theme from '../theme.config';
 import EzGlobalStyles from '../EzGlobalStyles';
@@ -29,7 +29,7 @@ const frame = theme.css({
   flexDirection: 'column',
 });
 
-const EzAppLayout: React.FC<Props> = ({children, layout}) => {
+const EzAppLayout: FC<PropsWithChildren<Props>> = ({children, layout}) => {
   return (
     <div className={frame()}>
       <EzGlobalStyles />

--- a/packages/recipe/src/components/EzCalendar/EzCalendar.tsx
+++ b/packages/recipe/src/components/EzCalendar/EzCalendar.tsx
@@ -1,4 +1,12 @@
-import React, {useEffect, useRef, createRef, useState} from 'react';
+import React, {
+  createRef,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ForwardRefRenderFunction,
+} from 'react';
 import dayjs from 'dayjs';
 import theme from '../theme.config';
 import EzButton from '../EzButton';
@@ -104,7 +112,7 @@ const EzCalendar = ({value, onChange, minDate, maxDate, filterDate}, ref) => {
   const [focusedDate, setFocusedDate] = useState(selectedDate);
   const focusTarget = useRef<HTMLButtonElement>();
 
-  React.useImperativeHandle(ref, () => ({
+  useImperativeHandle(ref, () => ({
     focus() {
       focusTarget.current.focus();
     },
@@ -239,4 +247,4 @@ const EzCalendar = ({value, onChange, minDate, maxDate, filterDate}, ref) => {
 
 type Handles = {focus: () => void};
 
-export default React.forwardRef(EzCalendar as React.RefForwardingComponent<Handles, any>);
+export default forwardRef(EzCalendar as ForwardRefRenderFunction<Handles, any>);

--- a/packages/recipe/src/components/EzCard/EzCard.tsx
+++ b/packages/recipe/src/components/EzCard/EzCard.tsx
@@ -113,7 +113,12 @@ const EzCard: React.FC<DOMProps & EzCardProps> = ({
         )}
         {title && (
           <EzHeader>
-            <EzCardHeading {...{actions, title, subtitle, titleIcon}} />
+            <EzCardHeading
+              actions={actions}
+              title={title}
+              subtitle={subtitle}
+              titleIcon={titleIcon}
+            />
           </EzHeader>
         )}
         {hasContentSlot(children) ? (

--- a/packages/recipe/src/components/EzCard/EzCardHeading.tsx
+++ b/packages/recipe/src/components/EzCard/EzCardHeading.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {FC, type HTMLAttributes, type ReactNode} from 'react';
 import EzHeading from '../EzHeading';
 import EzLayout from '../EzLayout';
 import theme from '../theme.config';
@@ -6,25 +6,25 @@ import theme from '../theme.config';
 const box = theme.css({position: 'relative'});
 
 type PropsWithoutTitle = {
-  subtitle?: never;
   actions?: never;
+  subtitle?: never;
   title?: never;
   titleIcon?: never;
 };
 
 type PropsWithTitle = {
+  actions?: ReactNode;
   subtitle?: string;
-  actions?: React.ReactNode;
   title: string;
-  titleIcon?: React.ReactNode | React.ComponentType;
+  titleIcon?: ReactNode;
 };
 
 type Props = PropsWithTitle | PropsWithoutTitle;
-type DOMProps = React.HTMLAttributes<HTMLElement>;
+type DOMProps = HTMLAttributes<HTMLElement>;
 
 export type HeadingProps = DOMProps & Props;
 
-const EzCardHeading: React.FC<HeadingProps> = ({title, subtitle, actions, titleIcon}) => {
+const EzCardHeading: FC<HeadingProps> = ({title, subtitle, actions, titleIcon}) => {
   const heading = title && (
     <EzLayout layout="basic" alignY="top">
       {titleIcon}

--- a/packages/recipe/src/components/EzFlashMessage/EzFlashMessage.tsx
+++ b/packages/recipe/src/components/EzFlashMessage/EzFlashMessage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, {type ReactNode, useEffect} from 'react';
 import theme from '../theme.config';
 import EzLayout from '../EzLayout';
 import EzHeading from '../EzHeading';
@@ -11,6 +11,7 @@ type EzFlashMessageUses = 'success' | 'error' | 'warning' | 'info';
 type FlashMessageProps = {
   autohide?: boolean;
   autohideDuration?: number;
+  children?: ReactNode;
   headline?: string;
   onAutohide?: () => void;
   onDismiss?: () => void;

--- a/packages/recipe/src/components/EzFormControlLabel/EzFormControlLabel.types.ts
+++ b/packages/recipe/src/components/EzFormControlLabel/EzFormControlLabel.types.ts
@@ -1,5 +1,4 @@
-import {ReactElement, ReactNode} from 'react';
-import {EzIconTypes} from '../EzIcon/EzIcon.types';
+import type {ReactElement, ReactNode} from 'react';
 
 export type Ref = HTMLDivElement;
 
@@ -13,11 +12,11 @@ export type EzFormControlLabelCommonProps = {
 export type FormControlLabelProps = EzFormControlLabelCommonProps & {
   helperText?: string;
   label: ReactNode;
-  labelIcons?: EzIconTypes[];
+  labelIcons?: ReactNode[];
 };
 
 export type SuperFormControlLabelProps = EzFormControlLabelCommonProps & {
-  icon: EzIconTypes;
+  icon: ReactNode;
   label?: ReactNode;
 };
 

--- a/packages/recipe/src/components/EzFormControlLabel/Implementations/EzFormControlLabelMui.tsx
+++ b/packages/recipe/src/components/EzFormControlLabel/Implementations/EzFormControlLabelMui.tsx
@@ -3,7 +3,6 @@ import {Box, FormControlLabel, Stack, useTheme} from '@mui/material';
 import {EzFormControlLabelProps, Ref} from '../EzFormControlLabel.types';
 import EzSuperFormControlLabel from '../../EzSuperFormControlLabel';
 import {useThemeColor} from '../../../themes/hooks/useThemeColor';
-import {EzIconTypes} from '../../EzIcon/EzIcon.types';
 import {isSuperFormControlLabel} from '../utils';
 
 const EzFormControlLabelMui = forwardRef<Ref, EzFormControlLabelProps>((props, ref) => {
@@ -39,7 +38,7 @@ const EzFormControlLabelMui = forwardRef<Ref, EzFormControlLabelProps>((props, r
           <Stack direction="row">
             {label}
 
-            {labelIcons?.map((labelIcon: EzIconTypes, index: number) => (
+            {labelIcons?.map((labelIcon, index: number) => (
               <Box ml={1} key={index}>
                 {labelIcon}
               </Box>

--- a/packages/recipe/src/components/EzIcon/EzIcon.types.ts
+++ b/packages/recipe/src/components/EzIcon/EzIcon.types.ts
@@ -1,17 +1,16 @@
-import {
+import type {
   ComponentClass,
   ComponentProps,
   FunctionComponent,
   ReactElement,
   ReactNode,
-  SVGProps,
 } from 'react';
 import {IconDefinition} from '@fortawesome/fontawesome-svg-core';
 import {SvgIcon} from '@mui/material';
 import {EzThemeColors, EzThemeIconSizes} from '../../themes/themes.types';
 
 export type EzCaterIconProps = string | FunctionComponent | ComponentClass;
-export type SvgIconProps = SVGProps<SVGSVGElement> | ReactElement;
+export type SvgIconProps = ReactElement;
 export type FontAwesomeIconProps = IconDefinition;
 export type EzIconTypes = EzCaterIconProps | FontAwesomeIconProps | SvgIconProps;
 export type SvgIconColorType = ComponentProps<typeof SvgIcon>['color'];

--- a/packages/recipe/src/components/EzLayout/EzLayout.tsx
+++ b/packages/recipe/src/components/EzLayout/EzLayout.tsx
@@ -1,4 +1,4 @@
-import React, {HTMLAttributes} from 'react';
+import React, {HTMLAttributes, type PropsWithChildren} from 'react';
 import {VariantProps} from '@stitches/core';
 import theme from '../theme.config';
 import {domProps, responsiveProps} from '../../utils';
@@ -108,7 +108,11 @@ type Props = Omit<HTMLAttributes<HTMLElement>, 'as' | 'css'> &
 /**
  * Layout provide common ways to arrange content in a single horizontal row.
  */
-const EzLayout: React.FC<Props> = ({children, className, ...initialProps}: any) => {
+const EzLayout: React.FC<PropsWithChildren<Props>> = ({
+  children,
+  className,
+  ...initialProps
+}: any) => {
   const props = responsiveProps(initialProps, true, 'layout', 'alignX', 'alignY', 'columns');
 
   // Note: The layout component needs to the respect white space that might be applied by a parent layout component.

--- a/packages/recipe/src/components/EzLink/EzLink.types.ts
+++ b/packages/recipe/src/components/EzLink/EzLink.types.ts
@@ -1,3 +1,5 @@
+import React, {type ComponentType, type MouseEventHandler, type ReactNode} from 'react';
+
 export type AnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string;
 };
@@ -7,10 +9,10 @@ export type Path = string;
 export type Location = any;
 export type LinkProps = {
   to: Path | Location;
-  as: React.ComponentType<{to: string}>;
+  as: ComponentType<{to: string; children?: ReactNode}>;
 };
 
-export type Clickable = {onClick: React.MouseEventHandler};
+export type Clickable = {onClick: MouseEventHandler};
 
 export type Labelled = Partial<Clickable> & {
   label: string;

--- a/packages/recipe/src/components/EzModal/EzModal.tsx
+++ b/packages/recipe/src/components/EzModal/EzModal.tsx
@@ -1,4 +1,4 @@
-import React, {MouseEvent} from 'react';
+import React, {type MouseEvent, type ReactNode} from 'react';
 import theme from '../theme.config';
 import EzButton from '../EzButton';
 import EzHeading from '../EzHeading';
@@ -71,15 +71,16 @@ const icon = theme.css({
 });
 
 type Props = {
-  headerText?: string;
+  appElement?: string;
+  children?: ReactNode;
   destructive?: boolean;
+  dismissLabel?: string;
+  headerText?: string;
   isOpen: boolean;
   isSubmitting?: boolean;
   onDismiss?: (e?: MouseEvent<HTMLButtonElement>) => void;
   onSubmit?: (e?: MouseEvent<HTMLButtonElement>) => void;
-  appElement?: string;
   submitLabel?: string;
-  dismissLabel?: string;
 };
 
 const useDialogBackdrop = ({onDismiss}) => ({

--- a/packages/recipe/src/components/EzNavigation/EzNavigation.tsx
+++ b/packages/recipe/src/components/EzNavigation/EzNavigation.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import React, {FC, useState, ReactElement} from 'react';
+import React, {FC, type ReactElement, type ReactNode, useState} from 'react';
 import theme from '../theme.config';
 import en from './en';
 import Logo, {LogoType} from './Logo';
@@ -44,10 +44,11 @@ type UserMenu = {
 };
 
 type Props = {
-  links: NavLink[];
-  utilityLinks?: UtilityLink[];
-  userMenu?: UserMenu;
+  children?: ReactNode;
   home: HomeLink;
+  links: NavLink[];
+  userMenu?: UserMenu;
+  utilityLinks?: UtilityLink[];
 };
 
 const wrapper = theme.css({

--- a/packages/recipe/src/components/EzNavigation/Hamburger.tsx
+++ b/packages/recipe/src/components/EzNavigation/Hamburger.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react';
+import React, {FC, type PropsWithChildren} from 'react';
 import theme from '../theme.config';
 import {clsx} from '../../utils';
 
@@ -6,10 +6,12 @@ type OpenProps = {
   opened: boolean;
 };
 
-type HamburgerProps = OpenProps & {
-  onClick: (ev: React.SyntheticEvent<any>) => void;
-  className: string;
-};
+type HamburgerProps = PropsWithChildren<
+  OpenProps & {
+    onClick: (ev: React.SyntheticEvent<any>) => void;
+    className: string;
+  }
+>;
 
 const hamburgerBox = theme.css({
   position: 'relative',

--- a/packages/recipe/src/components/EzNavigation/Notifications.tsx
+++ b/packages/recipe/src/components/EzNavigation/Notifications.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react';
+import React, {FC, type PropsWithChildren} from 'react';
 import {VariantProps} from '@stitches/core';
 import theme from '../theme.config';
 
@@ -27,7 +27,7 @@ const notification = theme.css({
   defaultVariants: {use: 'default'},
 });
 
-type Props = VariantProps<typeof notification>;
+type Props = PropsWithChildren<VariantProps<typeof notification>>;
 
 export const Counter: FC<Props> = ({children, ...props}) => (
   <span className={notification(props)}>{children}</span>

--- a/packages/recipe/src/components/EzOrderSummary/EzOrderSummary.tsx
+++ b/packages/recipe/src/components/EzOrderSummary/EzOrderSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {FC, type ReactNode} from 'react';
 import en from './en';
 import {useTranslation} from '../../utils/hooks';
 import theme from '../theme.config';
@@ -31,7 +31,7 @@ type Summary = {
 };
 
 type ActionsProps = {
-  actions: React.ReactNode;
+  actions: ReactNode;
   title: string;
 };
 
@@ -121,7 +121,7 @@ const instructions = theme.css({
   padding: '$order-summary-instructions-py $order-summary-instructions-px',
 });
 
-const Item = ({item}) => {
+const Item: FC<{item: Item}> = ({item}) => {
   const {t} = useTranslation(en);
   return (
     <div>
@@ -157,7 +157,7 @@ const Item = ({item}) => {
 /**
  * An order summary is an at-a-glance breakdown of billable items that make up an order.
  */
-const EzOrderSummary: React.FC<Props> = ({actions, items, subtitle, tableware, title, summary}) => {
+const EzOrderSummary: FC<Props> = ({actions, items, subtitle, tableware, title, summary}) => {
   const {t} = useTranslation(en);
   return (
     <EzCard actions={actions} title={title} subtitle={subtitle}>

--- a/packages/recipe/src/components/EzPage/EzPageSection.tsx
+++ b/packages/recipe/src/components/EzPage/EzPageSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import theme from '../theme.config';
 import {usePageSection} from './EzPage';
 import {clsx} from '../../utils';
@@ -54,6 +54,7 @@ const sibling = theme.css({
 });
 
 type Props = {
+  children?: ReactNode;
   use: 'aside' | 'main' | 'horizontal';
 };
 

--- a/packages/recipe/src/components/EzSuperFormControlLabel/EzSuperFormControlLabel.types.ts
+++ b/packages/recipe/src/components/EzSuperFormControlLabel/EzSuperFormControlLabel.types.ts
@@ -1,5 +1,4 @@
-import {ReactElement, ReactNode} from 'react';
-import {EzIconTypes} from '../EzIcon/EzIcon.types';
+import {type ReactElement, type ReactNode} from 'react';
 
 export type Ref = HTMLDivElement;
 
@@ -7,7 +6,7 @@ export interface EzSuperFormControlLabelProps {
   checked?: boolean | undefined;
   control: ReactElement;
   disabled?: boolean;
-  icon: EzIconTypes;
+  icon: ReactNode;
   label?: ReactNode;
   value?: any;
 }

--- a/packages/recipe/src/components/EzTable/EzTable.types.ts
+++ b/packages/recipe/src/components/EzTable/EzTable.types.ts
@@ -1,15 +1,17 @@
+import type {ComponentType, MouseEvent, MouseEventHandler, ReactNode} from 'react';
+
 type Column = {
   heading: string;
   numeric?: boolean;
   defaultSort?: Direction;
   key?: string;
-  component?: React.ReactNode | React.ComponentType;
+  component?: ReactNode | ComponentType;
   sortable?: boolean;
-  icon?: React.ReactNode | React.ComponentType;
+  icon?: ReactNode | ComponentType;
   /**
    * @deprecated Use `key` to provide column identifier and `component` to provide a custom cell renderer.
    */
-  accessor?: React.ReactNode | React.ComponentType | string;
+  accessor?: ReactNode | ComponentType | string;
 };
 
 type Direction = 'asc' | 'desc';
@@ -19,21 +21,21 @@ type OnSortClickOptions = {
   direction: Direction;
 };
 
-type onSortClick = (event: React.MouseEvent<HTMLElement>, options: OnSortClickOptions) => void;
+type onSortClick = (event: MouseEvent<HTMLElement>, options: OnSortClickOptions) => void;
 
 type onRowsPerPageChange = (event: any) => void;
 
 type BulkSelection = {
   disableMultiPageSelection?: boolean;
-  onRowSelectClick: (event: React.MouseEvent<HTMLInputElement>, value: any) => void;
-  onBulkSelectClick: React.MouseEventHandler;
+  onRowSelectClick: (event: MouseEvent<HTMLInputElement>, value: any) => void;
+  onBulkSelectClick: MouseEventHandler;
   isRowSelected: (item: any) => boolean;
   totalRowsSelected: number;
 };
 
 type SelectAllOrNoneEnabled = {
-  onSelectAllClick: React.MouseEventHandler;
-  onSelectNoneClick: React.MouseEventHandler;
+  onSelectAllClick: MouseEventHandler;
+  onSelectNoneClick: MouseEventHandler;
 };
 
 type SelectAllOrNoneDisabled = {
@@ -42,7 +44,7 @@ type SelectAllOrNoneDisabled = {
 };
 
 type ActionsProps = {
-  actions: React.ReactNode | React.ComponentType;
+  actions: ReactNode;
   title?: string;
 };
 
@@ -59,8 +61,8 @@ type Pagination = {
   totalRows: number;
   rowsPerPage: number;
   rowsPerPageOptions: number[];
-  onPrevPageClick: React.MouseEventHandler;
-  onNextPageClick: React.MouseEventHandler;
+  onPrevPageClick: MouseEventHandler;
+  onNextPageClick: MouseEventHandler;
   onRowsPerPageChange: onRowsPerPageChange;
 };
 
@@ -97,7 +99,7 @@ type TableBase = {
   columns: Column[];
   items: any[];
   onSortClick?: onSortClick;
-  titleIcon?: React.ReactNode | React.ComponentType;
+  titleIcon?: ReactNode;
   fullWidth?: boolean;
   transparent?: boolean;
 };
@@ -131,10 +133,10 @@ export type Sortable = {
   direction: Direction;
   isSorted: (column: Column) => boolean;
   onClick: (
-    event: React.MouseEvent<HTMLElement>,
+    event: MouseEvent<HTMLElement>,
     column: Column,
     // eslint-disable-next-line no-shadow
-    callback: (event: React.MouseEvent<HTMLElement>, options: OnSortClickOptions) => void
+    callback: (event: MouseEvent<HTMLElement>, options: OnSortClickOptions) => void
   ) => void;
 };
 

--- a/packages/recipe/src/components/EzTable/TableCardSection.tsx
+++ b/packages/recipe/src/components/EzTable/TableCardSection.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react';
+import React, {FC, type PropsWithChildren} from 'react';
 import theme from '../theme.config';
 import {EzCardSection} from '../EzCard';
 import {clsx} from '../../utils';
@@ -18,10 +18,10 @@ const cardWithHeading = theme.css({
   },
 });
 
-type TableCardSectionProps = {
+type TableCardSectionProps = PropsWithChildren<{
   className?: string;
   showCardWithoutHeading?: boolean;
-};
+}>;
 
 const TableCardSection: FC<TableCardSectionProps> = ({
   children,

--- a/packages/recipe/src/components/EzThemeProvider/EzThemeProvider.types.ts
+++ b/packages/recipe/src/components/EzThemeProvider/EzThemeProvider.types.ts
@@ -1,5 +1,7 @@
+import type {ReactNode} from 'react';
 import {Theme} from '@mui/material/styles';
 
 export type EzThemeProviderProps = {
+  children?: ReactNode;
   theme: Theme;
 };

--- a/packages/recipe/src/components/EzThemeProvider/Implementations/EzThemeProviderMui.tsx
+++ b/packages/recipe/src/components/EzThemeProvider/Implementations/EzThemeProviderMui.tsx
@@ -1,9 +1,7 @@
-import React, {FC} from 'react';
+import React, {FC, type PropsWithChildren} from 'react';
 import {Theme, ThemeProvider} from '@mui/material';
 
-type EzThemeProviderMuiProps = {
-  theme: Theme;
-};
+type EzThemeProviderMuiProps = PropsWithChildren<{theme: Theme}>;
 
 const EzThemeProviderMui: FC<EzThemeProviderMuiProps> = ({theme, children}) => (
   <ThemeProvider theme={theme}>{children}</ThemeProvider>

--- a/packages/recipe/src/components/EzTimeline/EzTimeline.types.ts
+++ b/packages/recipe/src/components/EzTimeline/EzTimeline.types.ts
@@ -1,3 +1,5 @@
+import type {PropsWithChildren} from 'react';
+
 type OptionalLink =
   // requires link props (and does not allow anchor props)
   | {href: string; to: never; as: never}
@@ -6,13 +8,14 @@ type OptionalLink =
   // props of link and anchor are optional, but if you provide them, they must be complete
   | {to?: never; as?: never; href?: never};
 
-export type TimelineEventProps = {
+export type TimelineEventProps = PropsWithChildren<{
   title: string;
   time: string;
   status?: React.ReactElement;
   icon?: React.ReactElement;
-} & OptionalLink;
+}> &
+  OptionalLink;
 
-export type TimelineProps = {
+export type TimelineProps = PropsWithChildren<{
   expandable?: {expandLabel: string; onClick: React.MouseEventHandler};
-};
+}>;

--- a/packages/recipe/src/components/EzTimeline/EzTimelinePeriod.tsx
+++ b/packages/recipe/src/components/EzTimeline/EzTimelinePeriod.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Children, FC, type ReactNode} from 'react';
 import theme from '../theme.config';
 
 const heading = theme.css({
@@ -46,11 +46,11 @@ const list = theme.css({
   '&& > * + *': {marginTop: '$sizes$timeline-gap'},
 });
 
-const EzTimelinePeriod: React.FC<{label: string}> = ({label, children}) => (
+const EzTimelinePeriod: FC<{label: string; children: ReactNode}> = ({label, children}) => (
   <section>
     <h3 className={heading()}>{label}</h3>
     <ol className={list()}>
-      {React.Children.map(children, (child, i) => (
+      {Children.map(children, (child, i) => (
         <li key={i}>{child}</li>
       ))}
     </ol>

--- a/packages/recipe/src/components/Icons/index.tsx
+++ b/packages/recipe/src/components/Icons/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {type ReactNode, type SVGProps} from 'react';
 import theme from '../theme.config';
 import {clsx} from '../../utils';
 
@@ -24,7 +24,7 @@ const rotateAnimationStyles = theme.css({
 });
 
 type SvgProps = {
-  children: React.SVGProps<SVGSVGElement>;
+  children: ReactNode;
   title: string;
   className?: string;
 };
@@ -63,13 +63,13 @@ export const DotIcon = () => (
   </SvgIcon>
 );
 
-export const ErrorTriangle = (p: React.SVGProps<SVGSVGElement>) => (
+export const ErrorTriangle = (p: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 14 14" height="1rem" width="1rem" {...p}>
     <path d="M13.37 10.94c.12.24.16.49.11.74a1.08 1.08 0 01-1.06.89H1.58a1.08 1.08 0 01-1.06-.9c-.05-.24 0-.49.11-.73l5.42-9.4c.14-.23.33-.4.58-.48.25-.08.5-.08.74 0 .25.08.44.25.58.49l5.42 9.4zM7 9a1 1 0 00-.73.3 1 1 0 00-.3.74c0 .29.1.53.3.73.2.2.44.3.73.3a1 1 0 00.73-.3 1 1 0 00.3-.73 1 1 0 00-.3-.73A1 1 0 007 9zM6 5.27l.19 3.08c0 .06.02.11.08.16.05.06.11.08.19.08h1.08c.08 0 .14-.02.2-.08.05-.05.07-.1.07-.16L8 5.27a.29.29 0 00-.08-.21.26.26 0 00-.19-.08H6.28a.26.26 0 00-.2.08.29.29 0 00-.07.21z" />
   </svg>
 );
 
-export const ErrorIcon = (p: React.SVGProps<SVGSVGElement>) => (
+export const ErrorIcon = (p: SVGProps<SVGSVGElement>) => (
   <ErrorTriangle {...p} className={alignBaseline()} />
 );
 
@@ -124,7 +124,7 @@ export const WarningIcon = () => (
   </SvgIcon>
 );
 
-export const CalendarIcon = (p: React.SVGProps<SVGSVGElement>) => (
+export const CalendarIcon = (p: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 14 14" height="1rem" width="1rem" {...p}>
     <path
       d="M12.833 14H1.167A1.167 1.167 0 0 1 0 12.833v-10.5c0-.644.522-1.166 1.167-1.166h1.166v1.166H1.167v10.5h11.666v-10.5h-1.166V1.167h1.166c.645 0 1.167.522 1.167 1.166v10.5c0 .645-.522 1.167-1.167 1.167zM9.917 9.917h1.166a.583.583 0 1 1 0 1.166H9.917a.583.583 0 1 1 0-1.166zm0-2.334h1.166a.583.583 0 1 1 0 1.167H9.917a.583.583 0 1 1 0-1.167zm1.166-1.166H9.917a.583.583 0 1 1 0-1.167h1.166a.583.583 0 1 1 0 1.167zM10.5 3.5a.583.583 0 0 1-.583-.583V.583a.583.583 0 1 1 1.166 0v2.334a.583.583 0 0 1-.583.583zM8.167 1.167h1.166v1.166H8.167V1.167zm-1.75 8.75h1.166a.583.583 0 1 1 0 1.166H6.417a.583.583 0 1 1 0-1.166zm0-2.334h1.166a.583.583 0 1 1 0 1.167H6.417a.583.583 0 1 1 0-1.167zm1.166-1.166H6.417a.583.583 0 1 1 0-1.167h1.166a.583.583 0 1 1 0 1.167zM7 3.5a.583.583 0 0 1-.583-.583V.583a.583.583 0 1 1 1.166 0v2.334A.583.583 0 0 1 7 3.5zM4.667 1.167h1.166v1.166H4.667V1.167zm-1.75 8.75h1.166a.583.583 0 1 1 0 1.166H2.917a.583.583 0 1 1 0-1.166zm0-2.334h1.166a.583.583 0 1 1 0 1.167H2.917a.583.583 0 1 1 0-1.167zm1.166-1.166H2.917a.583.583 0 1 1 0-1.167h1.166a.583.583 0 1 1 0 1.167zM3.5 3.5a.583.583 0 0 1-.583-.583V.583a.583.583 0 1 1 1.166 0v2.334A.583.583 0 0 1 3.5 3.5z"
@@ -134,7 +134,7 @@ export const CalendarIcon = (p: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
-export const ClockIcon = (p: React.SVGProps<SVGSVGElement>) => (
+export const ClockIcon = (p: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 14 14" height="1rem" width="1rem" {...p}>
     <path
       fill="#8B99A6"
@@ -144,12 +144,12 @@ export const ClockIcon = (p: React.SVGProps<SVGSVGElement>) => (
 );
 
 type InsetIconProps = {
-  children: React.SVGProps<SVGSVGElement>;
+  children: ReactNode;
   insetY0?: boolean;
-  right0?: boolean;
-  pr2?: boolean;
   left0?: boolean;
   pl3?: boolean;
+  pr2?: boolean;
+  right0?: boolean;
   z1?: boolean;
 };
 

--- a/packages/recipe/src/components/utils/Placeholder/Placeholder.tsx
+++ b/packages/recipe/src/components/utils/Placeholder/Placeholder.tsx
@@ -1,14 +1,15 @@
-import React, {CSSProperties} from 'react';
+import React, {CSSProperties, FC, type ReactNode} from 'react';
 
 interface PlaceholderProps {
-  width?: CSSProperties['width'];
+  children?: ReactNode;
   height?: CSSProperties['height'];
-  minWidth?: CSSProperties['minWidth'];
   minHeight?: CSSProperties['minHeight'];
+  minWidth?: CSSProperties['minWidth'];
   style?: CSSProperties;
+  width?: CSSProperties['width'];
 }
 
-const Placeholder: React.FC<PlaceholderProps> = ({
+const Placeholder: FC<PlaceholderProps> = ({
   width = 'auto',
   height = 120,
   minWidth,

--- a/packages/recipe/src/components/utils/PropsTable/PropsTable.tsx
+++ b/packages/recipe/src/components/utils/PropsTable/PropsTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {FC} from 'react';
 import {Stack} from '@mui/material';
 import EzTable from '../../EzTable';
 
@@ -13,7 +13,7 @@ type PropsTableProps = {
   propsData: PropData[];
 };
 
-const PropsTable = ({propsData}: PropsTableProps) => {
+const PropsTable: FC<PropsTableProps> = ({propsData}) => {
   const MonospaceCell = ({text, color = 'inherit', deprecated = false}) => (
     <Stack
       color={color}

--- a/packages/recipe/test-utils.tsx
+++ b/packages/recipe/test-utils.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable filenames/match-regex */
-import React, {FC, ReactElement} from 'react';
+import React, {FC, type PropsWithChildren, type ReactElement} from 'react';
 import {configureAxe} from 'jest-axe';
 import {render, RenderOptions} from '@testing-library/react';
 import EzThemeProvider from './src/components/EzThemeProvider';
@@ -12,7 +12,7 @@ const axe = configureAxe({
   },
 });
 
-const ProviderStack: FC = ({children}) => (
+const ProviderStack: FC<PropsWithChildren<unknown>> = ({children}) => (
   <EzThemeProvider theme={ezTheme}>{children}</EzThemeProvider>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,9 +4156,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@>=16", "@types/react@^17", "@types/react@^17.0.44", "@types/react@^18.0.26":
-  version "17.0.44"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
-  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
+  version "17.0.65"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.65.tgz#95f6a2ab61145ffb69129d07982d047f9e0870cd"
+  integrity sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -14962,47 +14962,47 @@ tty-table@^4.1.5:
     wcwidth "^1.0.1"
     yargs "^17.7.1"
 
-turbo-darwin-64@1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.10.7.tgz#bf270105effd337c91ea1c81ae3a1678c0c95023"
-  integrity sha512-N2MNuhwrl6g7vGuz4y3fFG2aR1oCs0UZ5HKl8KSTn/VC2y2YIuLGedQ3OVbo0TfEvygAlF3QGAAKKtOCmGPNKA==
+turbo-darwin-64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.10.13.tgz#7abc33838bf74c7e7ba2955cb6acc40342d6964c"
+  integrity sha512-vmngGfa2dlYvX7UFVncsNDMuT4X2KPyPJ2Jj+xvf5nvQnZR/3IeDEGleGVuMi/hRzdinoxwXqgk9flEmAYp0Xw==
 
-turbo-darwin-arm64@1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.7.tgz#29aa580dfda9a17bcbcce86c84e9144ceacbfaab"
-  integrity sha512-WbJkvjU+6qkngp7K4EsswOriO3xrNQag7YEGRtfLoDdMTk4O4QTeU6sfg2dKfDsBpTidTvEDwgIYJhYVGzrz9Q==
+turbo-darwin-arm64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.13.tgz#89f2d14a28789e5eaf276a17fecd4116d61fd16d"
+  integrity sha512-eMoJC+k7gIS4i2qL6rKmrIQGP6Wr9nN4odzzgHFngLTMimok2cGLK3qbJs5O5F/XAtEeRAmuxeRnzQwTl/iuAw==
 
-turbo-linux-64@1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.10.7.tgz#25bb73f2c9644d187fac87804eaf8d1c8fffcb69"
-  integrity sha512-x1CF2CDP1pDz/J8/B2T0hnmmOQI2+y11JGIzNP0KtwxDM7rmeg3DDTtDM/9PwGqfPotN9iVGgMiMvBuMFbsLhg==
+turbo-linux-64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.10.13.tgz#803e2b351984ec81034dc4b6935cdfb0a7d7d572"
+  integrity sha512-0CyYmnKTs6kcx7+JRH3nPEqCnzWduM0hj8GP/aodhaIkLNSAGAa+RiYZz6C7IXN+xUVh5rrWTnU2f1SkIy7Gdg==
 
-turbo-linux-arm64@1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.10.7.tgz#dac37b50d37d1168a7bda5333499482a78eb78fe"
-  integrity sha512-JtnBmaBSYbs7peJPkXzXxsRGSGBmBEIb6/kC8RRmyvPAMyqF8wIex0pttsI+9plghREiGPtRWv/lfQEPRlXnNQ==
+turbo-linux-arm64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.10.13.tgz#92439a927ec98801be1be266016736be5730e40c"
+  integrity sha512-0iBKviSGQQlh2OjZgBsGjkPXoxvRIxrrLLbLObwJo3sOjIH0loGmVIimGS5E323soMfi/o+sidjk2wU1kFfD7Q==
 
-turbo-windows-64@1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.10.7.tgz#3c31915cec88395aaffb457532e39e33bd1407b4"
-  integrity sha512-7A/4CByoHdolWS8dg3DPm99owfu1aY/W0V0+KxFd0o2JQMTQtoBgIMSvZesXaWM57z3OLsietFivDLQPuzE75w==
+turbo-windows-64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.10.13.tgz#870815cdcb20f2480296c208778f9127be61eec6"
+  integrity sha512-S5XySRfW2AmnTeY1IT+Jdr6Goq7mxWganVFfrmqU+qqq3Om/nr0GkcUX+KTIo9mPrN0D3p5QViBRzulwB5iuUQ==
 
-turbo-windows-arm64@1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.10.7.tgz#6f86f3bb5cc1faf7c61def19f1c98807335b39c0"
-  integrity sha512-D36K/3b6+hqm9IBAymnuVgyePktwQ+F0lSXr2B9JfAdFPBktSqGmp50JNC7pahxhnuCLj0Vdpe9RqfnJw5zATA==
+turbo-windows-arm64@1.10.13:
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.10.13.tgz#2da38b71b1716732541dfc5bd7475dc0903921f8"
+  integrity sha512-nKol6+CyiExJIuoIc3exUQPIBjP9nIq5SkMJgJuxsot2hkgGrafAg/izVDRDrRduQcXj2s8LdtxJHvvnbI8hEQ==
 
 turbo@^1.2.5:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.10.7.tgz#af0cf5963b2121577f264c31a7a196f0e8b00510"
-  integrity sha512-xm0MPM28TWx1e6TNC3wokfE5eaDqlfi0G24kmeHupDUZt5Wd0OzHFENEHMPqEaNKJ0I+AMObL6nbSZonZBV2HA==
+  version "1.10.13"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.10.13.tgz#8050bcd09f8a20d5a626f41e86cd8760e49a0df6"
+  integrity sha512-vOF5IPytgQPIsgGtT0n2uGZizR2N3kKuPIn4b5p5DdeLoI0BV7uNiydT7eSzdkPRpdXNnO8UwS658VaI4+YSzQ==
   optionalDependencies:
-    turbo-darwin-64 "1.10.7"
-    turbo-darwin-arm64 "1.10.7"
-    turbo-linux-64 "1.10.7"
-    turbo-linux-arm64 "1.10.7"
-    turbo-windows-64 "1.10.7"
-    turbo-windows-arm64 "1.10.7"
+    turbo-darwin-64 "1.10.13"
+    turbo-darwin-arm64 "1.10.13"
+    turbo-linux-64 "1.10.13"
+    turbo-linux-arm64 "1.10.13"
+    turbo-windows-64 "1.10.13"
+    turbo-windows-arm64 "1.10.13"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## What did we change?
This PR upgrades Recipe to be compliant with React 18 [types](https://www.npmjs.com/package/@types/react) (specifically with `18.2.21`). These changes are also compliant with our current version of React 17 types and so I did not upgrade us to 18 yet as we are not yet on React 18.

## Why are we doing this?
Apps that use Recipe and React 18 are running into issues when upgrading to React 18 types. While they can still use React 17 types, we'd like to support React 18 types so they can too.

## Testing
To test, upgrade to the latest React [types](https://www.npmjs.com/package/@types/react) (`18.2.21`) and run `yarn type-check`. There should be no errors using either React 17 or React 18 types.

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes