### PR TITLE
EzField validation docs updated to be more clear around use of error and touched props [FEC-694]

### DIFF
--- a/.changeset/three-insects-fail.md
+++ b/.changeset/three-insects-fail.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: EzField validation docs updated to be more clear around use of error and touched props

--- a/packages/recipe/src/components/EzField/Documentation/EzField.mdx
+++ b/packages/recipe/src/components/EzField/Documentation/EzField.mdx
@@ -131,7 +131,12 @@ Validation lets the user know that there is a problem with the provided input.
 - Use the `error` prop to provide a validation message to display to the user. The presence of a value indicates that the field is currently in an invalid state.
 - Use the `touched` prop to indicate that the user has interacted with or has visited the field. This value is used to determine whether or not to show an error and helps to avoid overwhelming users with error messages for fields they have not interacted with.
 
-Note: Recipe doesn't maintain the value of `touched`, and instead expects the `touched` state to be managed within the application, typically via [formik](https://jaredpalmer.com/formik/) or another form validation library.
+<Unstyled>
+  <EzAlert
+    headline="Errors will only appear if the `touched` prop is true."
+    tagline="Recipe doesn't maintain the value of `touched`, and instead expects it to be managed within the application, typically via formik or another form validation library."
+  />
+</Unstyled>
 
 <Canvas of={ValidationStories.Validation} meta={ValidationStories} />
 

--- a/packages/recipe/src/components/EzField/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzField/Documentation/Stories/Default.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof EzField> = {
     },
     error: {
       control: {type: 'text'},
-      description: 'The error text of invalid input.',
+      description: 'The error text of invalid input. Will only display if `touched` is `true`.',
       type: {name: 'string'},
       table: {type: {summary: 'string'}},
     },


### PR DESCRIPTION
## What did we change?
- [docs: EzField validation docs updated to be more clear around use of error and touched props](https://github.com/ezcater/recipe/commit/c50dbec93bbda7b6b886fc22d1c665c92f0dc8d1) 

## Why are we doing this?
This was a [request](https://ezcater.atlassian.net/browse/FEC-693) that was initially created to fix a bug with EzField selects not working correctly with validation. It was found to be working correctly, but there was confusion as to why it wasn't working without `touched`. This PR adds clarification in the docs to prevent this in the future.

## Screenshot(s) / Gif(s):
<img width="857" alt="Screenshot 2023-08-29 at 8 45 51 AM" src="https://github.com/ezcater/recipe/assets/5418735/c41504f6-a670-4845-bf5f-1065cfd80ec5">
<img width="856" alt="Screenshot 2023-08-29 at 8 46 14 AM" src="https://github.com/ezcater/recipe/assets/5418735/df92604b-3d10-4769-a9ab-341fabdb5637">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes
