### PR TITLE
Add arg types to EzFlashMessage [FEC-816]

### DIFF
--- a/.changeset/silent-moons-battle.md
+++ b/.changeset/silent-moons-battle.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzFlashMessage

--- a/packages/recipe/src/components/EzFlashMessage/Documentation/EzFlashMessage.mdx
+++ b/packages/recipe/src/components/EzFlashMessage/Documentation/EzFlashMessage.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/blocks';
+import {Controls, Meta, Primary} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -11,11 +11,13 @@ import * as DefaultStories from './Stories/Default.stories';
 
 <MigrationAlert component="ez-flash-message" />
 
----
-
 Flash messages are used to display contextual messages related to content on the page. This could be an action that was just performed by the user or an action that should be taken by the user.
 
----
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzFlashMessage/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzFlashMessage/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,57 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
+import dedent from 'ts-dedent';
 import EzFlashMessage from '../../EzFlashMessage';
 
 const meta: Meta<typeof EzFlashMessage> = {
+  argTypes: {
+    autohide: {
+      control: {type: 'boolean'},
+      description:
+        'If true, the flash message with automatically hide after 5 seconds, or a specified time using `autohideDuration`.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    autohideDuration: {
+      control: {type: 'number'},
+      description: 'The duration of time after which the flash message will hide in `ms`.',
+      table: {
+        defaultValue: {summary: 5000},
+        type: {summary: 'number'},
+      },
+    },
+    headline: {
+      control: {type: 'text'},
+      description: 'The headline of the flash message.',
+      type: {name: 'string'},
+      table: {type: {summary: 'string'}},
+    },
+    onAutohide: {
+      action: 'automatically hidden',
+      control: {type: null},
+      description: 'Callback fired when the flash message is automatically hidden.',
+      table: {type: {summary: '() => void'}},
+    },
+    onDismiss: {
+      action: 'dismissed',
+      control: {type: null},
+      description: 'Callback fired when the flash message is dismissed.',
+      table: {type: {summary: '() => void'}},
+    },
+    use: {
+      control: {type: 'select'},
+      description: 'The color of the component. Supports theme palette properties and colors.',
+      options: ['error', 'info', 'success', 'warning'],
+      table: {
+        type: {
+          required: true,
+          summary: 'error | info | success | warning',
+        },
+      },
+    },
+  },
   component: EzFlashMessage,
   title: 'Feedback/EzFlashMessage',
 };
@@ -11,5 +60,24 @@ export default meta;
 type Story = StoryObj<typeof EzFlashMessage>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    headline: 'We saved that for you.',
+    onAutohide: undefined,
+    onDismiss: undefined,
+    use: 'success',
+  },
+  parameters: {
+    playroom: {
+      code: dedent`
+        <EzFlashMessage headline="We saved that for you." use="success">
+          No further action required, just letting you know! Your changes will take effect immediately.
+        </EzFlashMessage>
+      `,
+    },
+  },
+  render: args => (
+    <EzFlashMessage {...args}>
+      No further action required, just letting you know! Your changes will take effect immediately.
+    </EzFlashMessage>
+  ),
 };


### PR DESCRIPTION
## What did we change?
- [docs: add arg types to EzFlashMessage](https://github.com/ezcater/recipe/commit/3eea076a7a4be9b0f923e114c1ee864b58b6ac1b)

## Why are we doing this?
Part of our migration to storybook docs.

## Screenshot(s) / Gif(s):
<img width="1702" alt="Screenshot 2023-08-29 at 9 58 40 AM" src="https://github.com/ezcater/recipe/assets/5418735/6068616f-d8db-4b45-902e-40c644d92e1e">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes
