### PR TITLE
Add default story to EzFormLayout [FEC-817]

### DIFF
--- a/.changeset/polite-vans-allow.md
+++ b/.changeset/polite-vans-allow.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add default story to EzFormLayout

--- a/packages/recipe/src/components/EzFormLayout/Documentation/EzFormLayout.mdx
+++ b/packages/recipe/src/components/EzFormLayout/Documentation/EzFormLayout.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/blocks';
+import {Meta, Primary} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -12,6 +12,8 @@ import * as DefaultStories from './Stories/Default.stories';
 <MigrationAlert component="ez-form-layout" />
 
 Form layouts are used to arrange fields within a form using standard spacing. Fields are stacked vertically, but can be further grouped into rows using the `EzLayout` component.
+
+<Primary />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzFormLayout/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzFormLayout/Documentation/Stories/Default.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
+import dedent from 'ts-dedent';
+import EzField from '../../../EzField';
 import EzFormLayout from '../../EzFormLayout';
 
 const meta: Meta<typeof EzFormLayout> = {
@@ -11,5 +13,20 @@ export default meta;
 type Story = StoryObj<typeof EzFormLayout>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  parameters: {
+    playroom: {
+      code: dedent`
+        <EzFormLayout>
+          <EzField type="text" label="First name" />
+          <EzField type="text" label="Last name" />
+        </EzFormLayout>
+      `,
+    },
+  },
+  render: args => (
+    <EzFormLayout {...args}>
+      <EzField type="text" label="First name" />
+      <EzField type="text" label="Last name" />
+    </EzFormLayout>
+  ),
 };

--- a/packages/recipe/src/components/EzFormLayout/EzFormLayout.tsx
+++ b/packages/recipe/src/components/EzFormLayout/EzFormLayout.tsx
@@ -18,6 +18,8 @@ const EzFormLayout = forwardRef<HTMLDivElement, Props>((initProps, ref) => {
   return <div {...props} ref={ref} />;
 });
 
+EzFormLayout.displayName = 'EzFormLayout';
+
 /**
  * @component
  */


### PR DESCRIPTION
## What did we change?
- [docs: add default story to EzFormLayout](https://github.com/ezcater/recipe/commit/9faa8e90757f70c0693fdf416901ab32067b74ac)

## Why are we doing this?
Part of our migration to storybook docs.

_Note: This component has no args, so no arg types were added._

## Screenshot(s) / Gif(s):
<img width="1698" alt="Screenshot 2023-08-29 at 11 13 20 AM" src="https://github.com/ezcater/recipe/assets/5418735/8b275323-5420-4610-83f1-6a8ddc0fb4af">
<img width="1700" alt="Screenshot 2023-08-29 at 11 13 39 AM" src="https://github.com/ezcater/recipe/assets/5418735/e6e4f4ea-3780-487b-91be-a147157580cb">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes