### PR TITLE
Add arg types to EzHeading [FEC-818]

### DIFF
--- a/.changeset/dirty-cameras-learn.md
+++ b/.changeset/dirty-cameras-learn.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzHeading

--- a/packages/recipe/src/components/EzHeading/Documentation/EzHeading.mdx
+++ b/packages/recipe/src/components/EzHeading/Documentation/EzHeading.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/blocks';
+import {Controls, Meta, Primary} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -12,6 +12,12 @@ import * as DefaultStories from './Stories/Default.stories';
 <MigrationAlert component="ez-heading" />
 
 Headings are the primary way of styling text in Recipe. Use them to create visual hierarchy on the page.
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzHeading/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzHeading/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,57 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
-import EzHeading from '../../EzHeading';
+import EzHeading, {EzHeadingProps} from '../../EzHeading';
 
 const meta: Meta<typeof EzHeading> = {
+  argTypes: {
+    align: {
+      control: {type: 'select'},
+      description:
+        "The alignment of the heading element. Supports responsive layouts, ex. `{base: 'left', medium: 'center'}`.",
+      options: ['center', 'left', 'right'],
+      table: {type: {summary: 'center | left | right'}},
+      type: {name: 'string'},
+    },
+    as: {
+      control: {type: 'select'},
+      description: 'The element type for the heading (overrides corresponding size element type).',
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+      table: {type: {summary: 'h1 | h2 | h3 | h4 | h5 | h6'}},
+      type: {name: 'string'},
+    },
+    casing: {
+      control: {type: 'select'},
+      description: 'The casing of the heading element.',
+      options: ['uppercase'],
+      table: {type: {summary: 'uppercase'}},
+    },
+    color: {
+      control: {type: 'select'},
+      description: 'The color of the heading element.',
+      options: ['blue', 'green'],
+      table: {type: {summary: 'blue | green'}},
+      type: {name: 'string'},
+    },
+    size: {
+      control: {type: 'select'},
+      description: 'The size of the heading element.',
+      options: ['1', '2', '3', '4', '5', '6'],
+      table: {
+        type: {
+          required: true,
+          summary: '1 | 2 | 3 | 4 | 5 | 6',
+        },
+      },
+      type: {name: 'string', required: true},
+    },
+    subheading: {
+      control: {type: 'text'},
+      description:
+        'The subheading of the heading element. Can only be used for headings with `size="3"` or `size="5"`.',
+      type: {name: 'string'},
+      table: {type: {summary: 'string'}},
+    },
+  },
   component: EzHeading,
   title: 'Typography/EzHeading',
 };
@@ -11,5 +60,11 @@ export default meta;
 type Story = StoryObj<typeof EzHeading>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    size: '1',
+  },
+  parameters: {
+    playroom: {code: '<EzHeading size="1">Heading title</EzHeading>'},
+  },
+  render: (args: EzHeadingProps) => <EzHeading {...args}>Heading title</EzHeading>,
 };

--- a/packages/recipe/src/components/EzHeading/EzHeading.tsx
+++ b/packages/recipe/src/components/EzHeading/EzHeading.tsx
@@ -74,7 +74,10 @@ const alignCss = theme.css({
 type TextStyle = VariantProps<typeof headingCss>;
 type Alignment = VariantProps<typeof alignCss>;
 type Tag = React.ComponentType<any>;
-interface Props extends Omit<HTMLAttributes<HTMLElement>, 'as' | 'css'>, Alignment, TextStyle {
+export interface EzHeadingProps
+  extends Omit<HTMLAttributes<HTMLElement>, 'as' | 'css'>,
+    Alignment,
+    TextStyle {
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   subheading?: string;
   casing?: 'uppercase';
@@ -84,7 +87,7 @@ interface Props extends Omit<HTMLAttributes<HTMLElement>, 'as' | 'css'>, Alignme
 /**
  * Headings are used to create visual hierarchy in page content. They are the primary means of controlling typography.
  */
-const EzHeading = forwardRef<HTMLElement, Props>(
+const EzHeading = forwardRef<HTMLElement, EzHeadingProps>(
   (
     {children: title, subheading: subtitle, align, size, casing, color, as, ...additionalProps},
     ref


### PR DESCRIPTION
## What did we change?
- [docs: add arg types to EzHeading](https://github.com/ezcater/recipe/commit/d644fd7117c386621b874ec361381df50cb19654)

## Why are we doing this?
Part of our migration to storybook docs.

## Screenshot(s) / Gif(s):
<img width="1700" alt="Screenshot 2023-08-29 at 2 51 05 PM" src="https://github.com/ezcater/recipe/assets/5418735/037d8e90-0447-46b9-97f1-00ba69dd3b40">
<img width="1703" alt="Screenshot 2023-08-29 at 2 52 17 PM" src="https://github.com/ezcater/recipe/assets/5418735/35912e29-a0ef-492e-8d9f-6de3970873bc">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes