### PR TITLE
Add arg types to EzIcon [FEC-819]

### DIFF
--- a/.changeset/warm-jobs-refuse.md
+++ b/.changeset/warm-jobs-refuse.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzIcon

--- a/packages/recipe/src/components/EzIcon/Documentation/EzIcon.mdx
+++ b/packages/recipe/src/components/EzIcon/Documentation/EzIcon.mdx
@@ -1,4 +1,4 @@
-import {Meta, Unstyled} from '@storybook/blocks';
+import {Controls, Meta, Primary, Unstyled} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -13,6 +13,12 @@ import * as DefaultStories from './Stories/Default.stories';
 <MigrationAlert component="ez-icon" />
 
 Recipe provides icon support for Font Awesome, ezCater icons, and SVG icons.
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzIcon/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzIcon/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,62 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
+import {faCoffee, faStar} from '@fortawesome/free-solid-svg-icons';
+import dedent from 'ts-dedent';
 import EzIcon from '../../EzIcon';
+import {EzIconProps} from '../../EzIcon.types';
+
+const ICONS = {
+  faCoffee,
+  faStar,
+};
 
 const meta: Meta<typeof EzIcon> = {
+  argTypes: {
+    color: {
+      control: {type: 'select'},
+      description: 'The color of the icon. Supports theme palette properties and colors.',
+      options: [
+        'inherit',
+        'primary',
+        'secondary',
+        'alert',
+        'error',
+        'info',
+        'neutral',
+        'success',
+        'warning',
+        'common.red100',
+        'common.blue100',
+      ],
+      table: {
+        defaultValue: {summary: 'inherit'},
+        type: {summary: 'EzThemeColors'},
+      },
+    },
+    icon: {
+      control: {type: 'select'},
+      description: 'Icon element.',
+      options: Object.keys(ICONS),
+      mapping: ICONS,
+      table: {type: {summary: 'EzIconTypes'}},
+      type: {name: 'other', value: 'EzIconTypes', required: true},
+    },
+    size: {
+      control: {type: 'select'},
+      description: 'The size of the icon.',
+      options: ['small', 'medium', 'large', 'xlarge', 'inherit'],
+      table: {
+        defaultValue: {summary: 'medium'},
+        type: {summary: 'small | medium | large | xlarge | inherit'},
+      },
+    },
+    title: {
+      control: {type: 'text'},
+      description: 'The accessible title of the icon.',
+      type: {name: 'string'},
+      table: {type: {summary: 'string'}},
+    },
+  },
   component: EzIcon,
   title: 'Typography/EzIcon',
 };
@@ -11,5 +65,25 @@ export default meta;
 type Story = StoryObj<typeof EzIcon>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    color: 'inherit',
+    icon: faCoffee,
+    size: 'medium',
+    title: 'Coffee icon with EzIcon and Font Awesome',
+  },
+  parameters: {
+    playroom: {
+      code: dedent`
+      {(() => {
+        const {faCoffee} = require('@fortawesome/free-solid-svg-icons/faCoffee');
+        return (
+          <EzPage>
+            <EzIcon icon={faCoffee} title="Coffee icon with EzIcon and Font Awesome" />
+          </EzPage>
+        );
+      })()}
+      `,
+    },
+  },
+  render: (args: EzIconProps) => <EzIcon {...args} />,
 };


### PR DESCRIPTION
## What did we change?
- [docs: add arg types to EzIcon](https://github.com/ezcater/recipe/commit/33ab3e6750a77c66812a12e6c628868062678368)

## Why are we doing this?
Part of our migration to storybook docs.

## Screenshot(s) / Gif(s):
<img width="1700" alt="Screenshot 2023-08-30 at 2 41 12 PM" src="https://github.com/ezcater/recipe/assets/5418735/b56e7b4a-db2d-483f-b456-265d32ca490c">
<img width="1701" alt="Screenshot 2023-08-30 at 2 41 30 PM" src="https://github.com/ezcater/recipe/assets/5418735/0d95117b-ebcf-4bb4-ba2d-f38fad923451">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes