### PR TITLE
Add autocomplete-search type to EzField [FEC-849] [FEC-850] [FEC-852]

### DIFF
--- a/.changeset/clean-cats-compete.md
+++ b/.changeset/clean-cats-compete.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: add disabled option to EzField's select options

--- a/.changeset/green-pugs-divide.md
+++ b/.changeset/green-pugs-divide.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: add EzField autosuggest-search option for search fields with autocomplete lists

--- a/.changeset/violet-coats-tap.md
+++ b/.changeset/violet-coats-tap.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: EzField autosuggest list selections can now clear both programmatically and with the browser's built-in input clear button

--- a/packages/recipe/src/components/EzField/Documentation/EzField.mdx
+++ b/packages/recipe/src/components/EzField/Documentation/EzField.mdx
@@ -195,6 +195,18 @@ Autosuggest fields allow the user to filter longer lists of options to a set tha
 
 <Canvas of={AutosuggestStories.Autosuggest} meta={AutosuggestStories} />
 
+## Autosuggest search list
+
+#### `type="autosuggest-search"`
+
+Autosuggest search fields support the same features as `type="autosuggest"` except they will have a search icon adornment and will not have a dropdown icon. Follow the same guidelines as with autosuggest lists.
+
+<Canvas of={AutosuggestStories.AutosuggestSearch} meta={AutosuggestStories} />
+
+Autosuggest search fields can also be used with async data fetching as well as programmatic clears.
+
+<Canvas of={AutosuggestStories.AutosuggestAsyncSearch} meta={AutosuggestStories} />
+
 ## Date
 
 #### `type="date"`

--- a/packages/recipe/src/components/EzField/Documentation/Stories/Autosuggest.stories.tsx
+++ b/packages/recipe/src/components/EzField/Documentation/Stories/Autosuggest.stories.tsx
@@ -1,6 +1,9 @@
-import React, {useState} from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, {useEffect, useState} from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
 import dedent from 'ts-dedent';
+import EzButton from '../../../EzButton';
+import {EzCard} from '../../../EzCard';
 import EzField from '../../EzField';
 import {Props as EzFieldProps} from '../../EzField.types';
 import DefaultMeta, {Default} from './Default.stories';
@@ -111,6 +114,281 @@ export const Autosuggest: Story = {
         type="autosuggest"
         value={selectedOption}
       />
+    );
+  },
+};
+
+const AutosuggestSearchJSX = dedent`
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedOption, setSelectedOption] = useState(null);
+  
+  const data = [
+    'Albany, New York',
+    'Atlanta, Georgia',
+    'Augusta, Maine',
+    'Austin, Texas',
+    'Boise, Idaho',
+    'Boston, Massachusetts',
+    'Concord, New Hampshire',
+    'Denver, Colorado',
+    'Dover, Delaware',
+    'Hartford, Connecticut',
+    'Honolulu, Hawaii',
+    'Lansing, Michigan',
+    'Montgomery, Alabama',
+    'Olympia, Washington',
+    'Phoenix, Arizona',
+    'Providence, Rhode Island',
+    'Sacramento, California',
+    'Santa Fe, New Mexico',
+    'Tallahassee, Florida',
+    'Trenton, New Jersey',
+  ];
+
+  const cities = data.filter(city => city.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  return (
+    <EzField
+      label="Search"
+      onFilter={setSearchTerm}
+      onSelectionChange={setSelectedOption}
+      options={cities.map(value => ({label: value, value}))}
+      placeholder="Search a city..."
+      type="autosuggest-search"
+      value={selectedOption}
+    />
+  );
+`;
+
+export const AutosuggestSearch: Story = {
+  args: {
+    ...Default.args,
+    label: 'Search',
+    placeholder: 'Search a city...',
+    value: undefined,
+  },
+  parameters: {
+    docs: {source: {code: AutosuggestSearchJSX}},
+    playroom: {
+      code: dedent`
+        {(() => {
+          ${AutosuggestSearchJSX}
+        })()}
+      `,
+    },
+  },
+  render: function AutosuggestSearchRender(args: EzFieldProps) {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [selectedOption, setSelectedOption] = useState(null);
+
+    const data = [
+      'Albany, New York',
+      'Atlanta, Georgia',
+      'Augusta, Maine',
+      'Austin, Texas',
+      'Boise, Idaho',
+      'Boston, Massachusetts',
+      'Concord, New Hampshire',
+      'Denver, Colorado',
+      'Dover, Delaware',
+      'Hartford, Connecticut',
+      'Honolulu, Hawaii',
+      'Lansing, Michigan',
+      'Montgomery, Alabama',
+      'Olympia, Washington',
+      'Phoenix, Arizona',
+      'Providence, Rhode Island',
+      'Sacramento, California',
+      'Santa Fe, New Mexico',
+      'Tallahassee, Florida',
+      'Trenton, New Jersey',
+    ];
+
+    const cities = data.filter(city => city.toLowerCase().includes(searchTerm.toLowerCase()));
+
+    return (
+      <EzField
+        {...args}
+        onFilter={setSearchTerm}
+        onSelectionChange={setSelectedOption}
+        options={cities.map(value => ({label: value, value}))}
+        type="autosuggest-search"
+        value={selectedOption}
+      />
+    );
+  },
+};
+
+const AutosuggestAsyncSearchJSX = dedent`
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedOption, setSelectedOption] = useState('');
+
+  const data = [
+    {group: 'Order #', name: 'N83-HCU'},
+    {group: 'Orderer', name: 'James T. Kirk'},
+    {group: 'Orderer', name: 'Nyota Uhura'},
+    {group: 'Caterer', name: "Ana's Bakery"},
+    {group: 'Caterer', name: "Brandon's Cafe"},
+    {group: 'Caterer', name: 'Tacos Mexico'},
+    {group: 'Caterer', name: 'Brit Bakery'},
+    {group: 'Caterer', name: 'Corner Bakery'},
+    {group: 'Caterer', name: 'Bagels & More'},
+    {group: 'Caterer', name: 'Italian To Go'},
+    {group: 'Caterer', name: 'Goblin City Bakery'},
+    {group: 'Caterer', name: 'Retro Bakery'},
+  ];
+
+  // your loading status/options should take the place of these hooks
+  // this is purely to show a loading state example using EzField autosuggest search
+  const [loading, setLoading] = useState(false);
+  const [options, setOptions] = useState([]);
+
+  useEffect(() => {
+    if (searchTerm === '') {
+      setOptions(opts => (opts.length === 0 ? opts : []));
+      setLoading(false);
+      return undefined;
+    }
+
+    if (selectedOption === searchTerm) return undefined;
+
+    setLoading(true);
+
+    const timerId = setTimeout(() => {
+      const filteredData = data.filter(dataItem =>
+        dataItem.name.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+
+      setOptions(
+        filteredData.length === 0
+          ? [{label: 'No results', value: 'No results', disabled: true}]
+          : filteredData.map(dataItem => ({
+              label: dataItem.name,
+              value: dataItem.name,
+              group: dataItem.group,
+            }))
+      );
+      setLoading(false);
+    }, 1500);
+    return () => clearTimeout(timerId);
+  }, [searchTerm]);
+
+  const handleClearFilters = () => {
+    setSearchTerm('');
+    setSelectedOption('');
+    setOptions([]);
+  };
+
+  return (
+    <EzCard>
+      <EzField
+        label="Search"
+        loading={loading}
+        onFilter={setSearchTerm}
+        onSelectionChange={setSelectedOption}
+        options={loading ? [] : options}
+        placeholder="Search by order #, orderer, or caterer"
+        type="autosuggest-search"
+        value={selectedOption}
+      />
+      <EzButton color="destructive" onClick={handleClearFilters} size="small">
+        Clear
+      </EzButton>
+    </EzCard>
+  );
+`;
+
+export const AutosuggestAsyncSearch: Story = {
+  args: {
+    ...Default.args,
+    onChange: undefined,
+  },
+  parameters: {
+    docs: {source: {code: AutosuggestAsyncSearchJSX}},
+    playroom: {
+      code: dedent`
+        {(() => {
+          ${AutosuggestAsyncSearchJSX}
+        })()}
+      `,
+    },
+  },
+  render: function AutosuggestAsyncSearch() {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [selectedOption, setSelectedOption] = useState('');
+
+    const data = [
+      {group: 'Order #', name: 'N83-HCU'},
+      {group: 'Orderer', name: 'James T. Kirk'},
+      {group: 'Orderer', name: 'Nyota Uhura'},
+      {group: 'Caterer', name: "Ana's Bakery"},
+      {group: 'Caterer', name: "Brandon's Cafe"},
+      {group: 'Caterer', name: 'Tacos Mexico'},
+      {group: 'Caterer', name: 'Brit Bakery'},
+      {group: 'Caterer', name: 'Corner Bakery'},
+      {group: 'Caterer', name: 'Bagels & More'},
+      {group: 'Caterer', name: 'Italian To Go'},
+      {group: 'Caterer', name: 'Goblin City Bakery'},
+      {group: 'Caterer', name: 'Retro Bakery'},
+    ];
+
+    // your loading status/options should take the place of these hooks
+    // this is purely to show a loading state example using EzField autosuggest search
+    const [loading, setLoading] = useState(false);
+    const [options, setOptions] = useState([]);
+
+    useEffect(() => {
+      if (searchTerm === '') {
+        setOptions(opts => (opts.length === 0 ? opts : []));
+        setLoading(false);
+        return undefined;
+      }
+
+      if (selectedOption === searchTerm) return undefined;
+
+      setLoading(true);
+
+      const timerId = setTimeout(() => {
+        const filteredData = data.filter(dataItem =>
+          dataItem.name.toLowerCase().includes(searchTerm.toLowerCase())
+        );
+
+        setOptions(
+          filteredData.length === 0
+            ? [{label: 'No results', value: 'No results', disabled: true}]
+            : filteredData.map(dataItem => ({
+                label: dataItem.name,
+                value: dataItem.name,
+                group: dataItem.group,
+              }))
+        );
+        setLoading(false);
+      }, 1500);
+      return () => clearTimeout(timerId);
+    }, [searchTerm]);
+
+    const handleClearFilters = () => {
+      setSearchTerm('');
+      setSelectedOption('');
+      setOptions([]);
+    };
+
+    return (
+      <EzCard>
+        <EzField
+          label="Search"
+          loading={loading}
+          onFilter={setSearchTerm}
+          onSelectionChange={setSelectedOption as any}
+          options={loading ? [] : options}
+          placeholder="Search by order #, orderer, or caterer"
+          type="autosuggest-search"
+          value={selectedOption}
+        />
+        <EzButton color="destructive" onClick={handleClearFilters} size="small">
+          Clear
+        </EzButton>
+      </EzCard>
     );
   },
 };

--- a/packages/recipe/src/components/EzField/EzAutosuggest.tsx
+++ b/packages/recipe/src/components/EzField/EzAutosuggest.tsx
@@ -8,6 +8,7 @@ import EzTextInput from './EzTextInput';
 import {InsetIcon} from '../Icons';
 import {useComboBoxState, useComboBox} from './useComboBox';
 import theme from '../theme.config';
+import {useUpdateEffect} from '../../utils/hooks';
 
 const popper = theme.css({
   zIndex: '$autosuggest-z', // this is hard-coded in theme.config.ts for now, but we should really pull it in from mui when we convert autosuggest to mui
@@ -19,12 +20,24 @@ const iconWrapperStyle = theme.css({
   fontSize: '13px',
 });
 
-const EzAutosuggest = props => {
+const searchIconStyle = theme.css({
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: '12px center, calc(100% - 10px) center',
+  backgroundImage: '$search-input-background-image',
+  '&&': {
+    paddingLeft: '$search-input-padding-left',
+  },
+  WebkitAppearance: 'none',
+});
+
+const EzAutosuggest = ({loading, options, ...props}) => {
   const triggerRef = useRef<HTMLInputElement>();
   const listboxRef = useRef<unknown>();
   const ariaLabelledBy = props['aria-labelledby'];
 
-  const state = useComboBoxState(props);
+  const loadingOptions = [{label: 'Loading...', value: 'loading', disabled: true}];
+  const stateOptions = loading ? loadingOptions : options;
+  const state = useComboBoxState({options: stateOptions, ...props});
   const {inputProps, listBoxProps} = useComboBox(
     {
       ...props,
@@ -34,15 +47,34 @@ const EzAutosuggest = props => {
     state
   );
 
+  useUpdateEffect(() => {
+    if (props.value != null) state.setInputValue(props.value);
+  }, [props.value]);
+
   return (
     <div>
-      <TextInputWrapper className={props.className} disabled={props.disabled}>
-        <EzTextInput {...inputProps} ref={triggerRef} error={props.error} touched={props.touched} />
-        <InsetIcon insetY0 right0 pr2>
-          <div className={iconWrapperStyle()}>
-            <EzIcon icon={state.isOpen ? faChevronUp : faChevronDown} size="inherit" />
-          </div>
-        </InsetIcon>
+      <TextInputWrapper
+        className={props.className}
+        disabled={props.disabled}
+        css={{
+          '&& input': {paddingRight: props.type === 'autosuggest-search' ? '0.5em' : undefined},
+        }}
+      >
+        <EzTextInput
+          {...inputProps}
+          className={props.type === 'autosuggest-search' ? searchIconStyle() : undefined}
+          error={props.error}
+          ref={triggerRef}
+          touched={props.touched}
+          type="search"
+        />
+        {props.type === 'autosuggest' && (
+          <InsetIcon insetY0 right0 pr2>
+            <div className={iconWrapperStyle()}>
+              <EzIcon icon={state.isOpen ? faChevronUp : faChevronDown} size="inherit" />
+            </div>
+          </InsetIcon>
+        )}
       </TextInputWrapper>
       {state.isOpen && (
         <EzPopover
@@ -57,11 +89,11 @@ const EzAutosuggest = props => {
           <EzListBox
             {...listBoxProps}
             aria-labelledby={[ariaLabelledBy, props.id].join(' ')}
-            ref={listboxRef}
-            onClick={() => triggerRef.current.focus()}
             collection={state.collection}
-            selectionManager={state.selectionManager}
+            onClick={() => triggerRef.current.focus()}
+            ref={listboxRef}
             searchWords={[inputProps.value]}
+            selectionManager={state.selectionManager}
           />
         </EzPopover>
       )}

--- a/packages/recipe/src/components/EzField/EzField.tsx
+++ b/packages/recipe/src/components/EzField/EzField.tsx
@@ -32,7 +32,7 @@ const EzCustomInput = forwardRef<HTMLElement, CustomInputProps>(({type: Input, .
 const resolveInputFromType = type => {
   if (type === 'date') return EzDateInput;
   if (type === 'select') return EzSelect;
-  if (type === 'autosuggest') return EzAutosuggest;
+  if (type === 'autosuggest' || type === 'autosuggest-search') return EzAutosuggest;
   if (type === 'time') return EzTimeInput;
   if (type === 'textarea') return EzTextArea;
   if (inputElements.includes(type)) return EzTextInput;

--- a/packages/recipe/src/components/EzField/EzField.types.ts
+++ b/packages/recipe/src/components/EzField/EzField.types.ts
@@ -62,6 +62,11 @@ type AutosuggestInputProps = {
   onSelectionChange?: (key: Key) => any;
 };
 
+type AutosuggesSearchInputProps = Omit<AutosuggestInputProps, 'type'> & {
+  type: 'autosuggest-search';
+  loading?: boolean;
+};
+
 type CustomFieldProps = {
   type: React.FC<any> | React.ComponentClass<any>;
   value?: any;
@@ -75,6 +80,7 @@ type FieldTypeProps =
   | TimeInputProps
   | TextAreaInputProps
   | AutosuggestInputProps
+  | AutosuggesSearchInputProps
   | CustomFieldProps;
 
 type ErrorOrMessage = string | boolean;

--- a/packages/recipe/src/components/EzField/EzListBox.tsx
+++ b/packages/recipe/src/components/EzField/EzListBox.tsx
@@ -55,6 +55,11 @@ const listItemOption = theme.css({
   },
 });
 
+const disabledOption = theme.css({
+  pointerEvents: 'none',
+  opacity: 0.6,
+});
+
 const OptGroup = props => {
   const id = useUniqueId();
   return (
@@ -94,7 +99,11 @@ const EzListBox = (props, ref) => {
     return (
       <li
         role="option"
-        className={clsx(listItem(), listItemOption({current, selected}))}
+        className={clsx(
+          listItem(),
+          listItemOption({current, selected}),
+          option.disabled && disabledOption()
+        )}
         aria-current={current}
         aria-selected={selected}
         ref={selected || shouldReceiveFocus ? (activeOptionRef as any) : undefined}
@@ -114,7 +123,7 @@ const EzListBox = (props, ref) => {
               highlightStyle={{
                 backgroundColor: 'inherit',
                 color: 'currentColor',
-                textDecoration: 'underline',
+                textDecoration: option.disabled ? undefined : 'underline',
               }}
             />
             {option.description && <EzTextStyle use="subdued">{option.description}</EzTextStyle>}


### PR DESCRIPTION
## What did we change?
- [feat: add autocomplete-search type to EzField](https://github.com/ezcater/recipe/commit/e35cb5014e3933952f88c194a6f531a0c276fdd9)

## Why are we doing this?
This feature was added to support a [request](https://ezcater.atlassian.net/browse/FEC-723) for autocomplete search lists, including handling async data loading and clearing selections both in the input and programmatically. Added to docs.

## Screenshot(s) / Gif(s):
<img width="1705" alt="Screenshot 2023-09-05 at 9 20 55 AM" src="https://github.com/ezcater/recipe/assets/5418735/075f26f0-727c-4762-a642-2ddface6e641">
<img width="1167" alt="Screenshot 2023-09-05 at 9 22 13 AM" src="https://github.com/ezcater/recipe/assets/5418735/6d9eafe8-467f-43c1-a0c4-4ced82e59e69">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes