### PR TITLE
Add width option to EzTable columns [FEC-837] [FEC-848]

### DIFF
--- a/.changeset/olive-donuts-matter.md
+++ b/.changeset/olive-donuts-matter.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: add width option to EzTable columns

--- a/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
+++ b/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
@@ -1,4 +1,4 @@
-import {Meta, Unstyled} from '@storybook/blocks';
+import {Controls, Meta, Primary, Unstyled} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -31,6 +31,12 @@ Features still in consideration include:
 - Column width options (fixed, grow, auto, ellipsis, tooltip)
 - Header-less columns (content between columns, e.g. formula operators)
 - Sticky headers
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,153 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
+import {faCoffee, faStar} from '@fortawesome/free-solid-svg-icons';
+import dedent from 'ts-dedent';
+import EzIcon from '../../../EzIcon';
 import EzTable from '../../EzTable';
+import {TableProps} from '../../EzTable.types';
+import EzButton from '../../../EzButton';
+
+const ICONS = {
+  faCoffee: <EzIcon icon={faCoffee} />,
+  faStar: <EzIcon icon={faStar} />,
+};
 
 const meta: Meta<typeof EzTable> = {
+  argTypes: {
+    actions: {
+      control: {type: 'node'},
+      description: 'The actions of the table. Must be used with table header.',
+      table: {type: {summary: 'ReactNode'}},
+    },
+    ariaLabel: {
+      control: {type: 'text'},
+      description: 'The aria label of the table.',
+      table: {type: {summary: 'string'}},
+      type: {name: 'string'},
+    },
+    columns: {
+      control: {type: 'array'},
+      description: 'Array of columns for the table.',
+      table: {
+        type: {
+          summary: `
+            Column[
+              component?: ReactNode | ComponentType;
+              defaultSort?: 'asc' | 'desc';
+              heading: string;
+              icon?: ReactNode | ComponentType;
+              key?: string;
+              numeric?: boolean;
+              sortable?: boolean;
+            ]
+          `,
+        },
+      },
+      type: {name: 'other', value: 'Column[]', required: true},
+    },
+    fullWidth: {
+      control: {type: 'boolean'},
+      description: 'If true, the table will be full width.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    items: {
+      control: {type: 'array'},
+      description: 'Array of items for the table.',
+      table: {type: {summary: 'any[]'}},
+      type: {name: 'other', value: 'Column[]', required: true},
+    },
+    onSortClick: {
+      control: {type: 'func'},
+      description: 'The callback function called when a column header is pressed.',
+      table: {
+        type: {
+          summary: `(
+            event: MouseEvent<HTMLElement>,
+            options: OnSortClickOptions: {
+              column: Column;
+              direction: 'asc' | 'desc';
+            }
+          ) => void`,
+        },
+      },
+    },
+    pagination: {
+      control: {type: 'object'},
+      description: 'The pagination options for the table.',
+      table: {
+        type: {
+          summary: `
+            Pagination: {
+              currentPage: number;
+              onNextPageClick: MouseEventHandler;
+              onPrevPageClick: MouseEventHandler;
+              onRowsPerPageChange: onRowsPerPageChange;
+              rowsPerPage: number;
+              rowsPerPageOptions: number[];
+              totalFilteredRows?: number;
+              totalRows: number;
+            }
+          `,
+        },
+      },
+    },
+    selection: {
+      control: {type: 'object'},
+      description: 'The selection options for the table.',
+      table: {
+        type: {
+          summary: `
+            Selection: {
+              disableMultiPageSelection?: boolean;
+              isRowSelected: (item: any) => boolean;
+              onBulkSelectClick: MouseEventHandler;
+              onRowSelectClick: (event: MouseEvent<HTMLInputElement>, value: any) => void;
+              onSelectAllClick?: MouseEventHandler;
+              onSelectNoneClick?: MouseEventHandler;
+              totalRowsSelected: number;
+            }
+          `,
+        },
+      },
+    },
+    showCardWithoutHeading: {
+      control: {type: 'boolean'},
+      description:
+        'If true, the table will render without a heading. Must be used along with `ariaLabel`.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    subtitle: {
+      control: {type: 'text'},
+      description: 'The subtitle of the table.',
+      table: {type: {summary: 'string'}},
+    },
+    title: {
+      control: {type: 'text'},
+      description: 'The title of the table.',
+      table: {type: {summary: 'string'}},
+    },
+    titleIcon: {
+      control: {type: 'select'},
+      description: 'The title icon of the table.',
+      mapping: ICONS,
+      options: Object.keys(ICONS),
+      table: {type: {summary: 'ReactNode'}},
+    },
+    transparent: {
+      control: {type: 'boolean'},
+      description: "If true, the table will inherit the parent element's background color.",
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+  },
   component: EzTable,
   title: 'Data Display/EzTable',
 };
@@ -11,5 +156,46 @@ export default meta;
 type Story = StoryObj<typeof EzTable>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    actions: <EzButton>Add store</EzButton>,
+    columns: [
+      {heading: 'Store name', key: 'store'},
+      {heading: 'Total sales', key: 'total', numeric: true},
+      {heading: 'Average order value', key: 'average', numeric: true},
+    ],
+    items: [
+      {id: '#004', store: 'Ten Forward', total: 23267, average: 327.79},
+      {id: '#007', store: "Sisko's Creole Kitchen", total: 22788, average: 367.55},
+    ],
+    subtitle: 'Compared to the same period last year',
+    title: 'All stores',
+    titleIcon: <EzIcon icon={faCoffee} size="large" />,
+  },
+  parameters: {
+    playroom: {
+      code: dedent`
+      {(() => {
+        const {faCoffee} = require('@fortawesome/free-solid-svg-icons/faCoffee');
+        return (
+          <EzTable
+            actions={<EzButton>Add store</EzButton>}
+            columns={[
+              {heading: 'Store name', key: 'store'},
+              {heading: 'Total sales', key: 'total', numeric: true},
+              {heading: 'Average order value', key: 'average', numeric: true},
+            ]}
+            items={[
+              {id: '#004', store: 'Ten Forward', total: 23267, average: 327.79},
+              {id: '#007', store: "Sisko's Creole Kitchen", total: 22788, average: 367.55},
+            ]}
+            subtitle="Compared to the same period last year"
+            title="All stores"
+            titleIcon={<EzIcon icon={faCoffee} size="large" />}
+          />
+        );
+      })()}
+      `,
+    },
+  },
+  render: (args: TableProps) => <EzTable {...args} />,
 };

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
@@ -6,6 +6,7 @@ import EzIcon from '../../../EzIcon';
 import EzTable from '../../EzTable';
 import {TableProps} from '../../EzTable.types';
 import EzButton from '../../../EzButton';
+import EzLayout from '../../../EzLayout';
 
 const ICONS = {
   faCoffee: <EzIcon icon={faCoffee} />,
@@ -39,6 +40,7 @@ const meta: Meta<typeof EzTable> = {
               key?: string;
               numeric?: boolean;
               sortable?: boolean;
+              width?: number;
             ]
           `,
         },
@@ -155,17 +157,41 @@ const meta: Meta<typeof EzTable> = {
 export default meta;
 type Story = StoryObj<typeof EzTable>;
 
+const ActionButtons = (
+  <EzLayout layout="right">
+    <EzButton fontSize="small" variant="text">
+      View
+    </EzButton>
+    <EzButton color="destructive" fontSize="small" variant="text">
+      Delete
+    </EzButton>
+  </EzLayout>
+);
+
 export const Default: Story = {
   args: {
     actions: <EzButton>Add store</EzButton>,
     columns: [
       {heading: 'Store name', key: 'store'},
-      {heading: 'Total sales', key: 'total', numeric: true},
-      {heading: 'Average order value', key: 'average', numeric: true},
+      {heading: 'Total sales', key: 'total', numeric: true, width: 100},
+      {heading: 'Average order value', key: 'average', numeric: true, width: 150},
+      {heading: '', key: 'actions'},
     ],
     items: [
-      {id: '#004', store: 'Ten Forward', total: 23267, average: 327.79},
-      {id: '#007', store: "Sisko's Creole Kitchen", total: 22788, average: 367.55},
+      {
+        id: '#004',
+        store: 'Ten Forward',
+        total: 23267,
+        average: 327.79,
+        actions: ActionButtons,
+      },
+      {
+        id: '#007',
+        store: "Sisko's Creole Kitchen",
+        total: 22788,
+        average: 367.55,
+        actions: ActionButtons,
+      },
     ],
     subtitle: 'Compared to the same period last year',
     title: 'All stores',
@@ -181,12 +207,25 @@ export const Default: Story = {
             actions={<EzButton>Add store</EzButton>}
             columns={[
               {heading: 'Store name', key: 'store'},
-              {heading: 'Total sales', key: 'total', numeric: true},
-              {heading: 'Average order value', key: 'average', numeric: true},
+              {heading: 'Total sales', key: 'total', numeric: true, width: 100},
+              {heading: 'Average order value', key: 'average', numeric: true, width: 150},
+              {heading: '', key: 'actions'},
             ]}
             items={[
-              {id: '#004', store: 'Ten Forward', total: 23267, average: 327.79},
-              {id: '#007', store: "Sisko's Creole Kitchen", total: 22788, average: 367.55},
+              {
+                id: '#004',
+                store: 'Ten Forward',
+                total: 23267,
+                average: 327.79,
+                actions: ActionButtons,
+              },
+              {
+                id: '#007',
+                store: "Sisko's Creole Kitchen",
+                total: 22788,
+                average: 367.55,
+                actions: ActionButtons,
+              },
             ]}
             subtitle="Compared to the same period last year"
             title="All stores"

--- a/packages/recipe/src/components/EzTable/EzTable.tsx
+++ b/packages/recipe/src/components/EzTable/EzTable.tsx
@@ -216,10 +216,20 @@ type ThProps = {
   isSortableColumn?: boolean;
   sorted?: boolean;
   onClick?: any;
+  width?: number;
 };
 
-const Th: FC<ThProps> = ({children, numeric, isSelection, isSortableColumn, sorted, onClick}) => (
-  <th
+const Th: FC<ThProps> = ({
+  children,
+  isSelection,
+  isSortableColumn,
+  numeric,
+  onClick,
+  sorted,
+  width,
+}) => (
+  <Box
+    component="th"
     className={clsx(
       isSelection ? checkboxCell() : cell(),
       numeric && numericCell(),
@@ -228,9 +238,10 @@ const Th: FC<ThProps> = ({children, numeric, isSelection, isSortableColumn, sort
       sorted && sortedCell()
     )}
     onClick={onClick}
+    width={width || 'auto'}
   >
     {children}
-  </th>
+  </Box>
 );
 
 const Thead = ({selectable}) => {
@@ -258,7 +269,7 @@ const Thead = ({selectable}) => {
           </Th>
         )}
         {columns.map((column, cellIndex) => {
-          const {sortable, heading, numeric, icon} = column;
+          const {sortable, heading, numeric, icon, width} = column;
           return (
             <Th
               key={column.key || cellIndex}
@@ -266,9 +277,10 @@ const Thead = ({selectable}) => {
               isSortableColumn={sortable}
               sorted={isSorted(column)}
               onClick={event => onClick(event, column, sorting.onSortClick)}
+              width={width}
             >
               <span className={headerItems()}>
-                {heading}
+                <Box whiteSpace="normal">{heading}</Box>
                 {icon && <span className={headerIcon()}>{icon}</span>}
                 {sortable && <SortIcon direction={direction} isSorted={isSorted(column)} />}
               </span>

--- a/packages/recipe/src/components/EzTable/EzTable.types.ts
+++ b/packages/recipe/src/components/EzTable/EzTable.types.ts
@@ -1,13 +1,14 @@
 import type {ComponentType, MouseEvent, MouseEventHandler, ReactNode} from 'react';
 
 type Column = {
-  heading: string;
-  numeric?: boolean;
-  defaultSort?: Direction;
-  key?: string;
   component?: ReactNode | ComponentType;
-  sortable?: boolean;
+  defaultSort?: Direction;
+  heading: string;
   icon?: ReactNode | ComponentType;
+  key?: string;
+  numeric?: boolean;
+  sortable?: boolean;
+  width?: number;
   /**
    * @deprecated Use `key` to provide column identifier and `component` to provide a custom cell renderer.
    */


### PR DESCRIPTION
## What did we change?
- [add arg types to EzTable](https://github.com/ezcater/recipe/commit/fd402160a4fc3e89ab264acffe5f36f7295361e2)
- [add width option to EzTable columns](https://github.com/ezcater/recipe/commit/61055af982331adfedfb26427965f0330c4ad2b2)

Note also that since column widths can now be defined, column headers can now wrap (separate from icons).

## Why are we doing this?
[Request](https://ezcater.atlassian.net/browse/FEC-846).

## Screenshot(s) / Gif(s):
<img width="1704" alt="Screenshot 2023-09-06 at 8 59 24 AM" src="https://github.com/ezcater/recipe/assets/5418735/cd7dbc7e-6e09-4dd0-a5fe-cda90da7215d">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes