### PR TITLE
Turn on Chromatic Turbosnap [FEC-854]

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,6 +24,6 @@ jobs:
           projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
           workingDir: packages/recipe
           exitOnceUploaded: true
-          onlyChanged: false # TODO: turn on after storybook-docs feature merged
+          onlyChanged: true # turbosnap (see https://www.chromatic.com/docs/turbosnap)
         env:
           STORYBOOK_INCLUDE_REGRESSION_STORIES: 1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,12 +18,26 @@ jobs:
         run: yarn build-playroom
         working-directory: ./packages/recipe
 
+      # this only applies to non-main branches (e.g., feature branches)
       - name: Publish to Chromatic
+        if: github.ref != 'refs/heads/main'
         uses: chromaui/action@v1
         with:
           projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
           workingDir: packages/recipe
           exitOnceUploaded: true
           onlyChanged: true # turbosnap (see https://www.chromatic.com/docs/turbosnap)
+        env:
+          STORYBOOK_INCLUDE_REGRESSION_STORIES: 1
+
+      # this only applies to the `main` branch
+      - name: Publish to Chromatic
+        if: github.ref == 'refs/heads/main'
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
+          workingDir: packages/recipe
+          exitOnceUploaded: true
+          autoAcceptChanges: true # `main` is the baseline
         env:
           STORYBOOK_INCLUDE_REGRESSION_STORIES: 1


### PR DESCRIPTION
## What did we change?
- [turn on chromatic turbosnap](https://github.com/ezcater/recipe/commit/7fc8f705868b47fd23647bbcf408ed8c2ea91232)

## Why are we doing this?
We had turned off [turbosnap](https://github.com/ezcater/recipe/pull/981) which was not working correctly with our gatsby site. Now that we have switched to storybook docs, we can turn it back on to help save us snapshots.

_No changeset is needed for this change that doesn't affect the Recipe library._