### PR TITLE
Fix chromatic bugs [FEC-855]

### DIFF
--- a/packages/recipe/src/components/EzBarChart/Documentation/Stories/AxisLabelValues.stories.tsx
+++ b/packages/recipe/src/components/EzBarChart/Documentation/Stories/AxisLabelValues.stories.tsx
@@ -36,7 +36,7 @@ export const DependentAxisLabelValues: Story = {
     data: DATA,
     dependentAxisLabelValues: [0, 50000, 100000, 150000, 200000, 250000, 300000],
     independentAxisLabelFormatter: (t: number) => {
-      const date = new Date();
+      const date = new Date('2023-01-01T12:00:00Z');
       date.setMonth(t - 1);
       return date.toLocaleString('en-US', {month: 'short'});
     },
@@ -61,7 +61,7 @@ export const DependentAxisLabelValues: Story = {
           ];
 
           const independentAxisLabelFormatter = (t: number) => {
-            const date = new Date();
+            const date = new Date('2023-01-01T12:00:00Z');
             date.setMonth(t - 1);
             return date.toLocaleString('en-US', {month: 'short'});
           };
@@ -101,7 +101,7 @@ export const DependentAxisLabelValues: Story = {
           ];
 
           const independentAxisLabelFormatter = t => {
-            const date = new Date();
+            const date = new Date('2023-01-01T12:00:00Z');
             date.setMonth(t - 1);
             return date.toLocaleString('en-US', {month: 'short'});
           };
@@ -175,7 +175,7 @@ export const IndependentAxisLabelValues: Story = {
         ];
       
         const independentAxisLabelFormatter = t => {
-          const date = new Date();
+          const date = new Date('2023-01-01T12:00:00Z');
           date.setMonth(t - 1);
           return date.toLocaleString('en-US', {month: 'short'});
         };

--- a/packages/recipe/src/components/EzBarChart/Documentation/Stories/MaxValue.stories.tsx
+++ b/packages/recipe/src/components/EzBarChart/Documentation/Stories/MaxValue.stories.tsx
@@ -36,7 +36,7 @@ export const MaxDependentValue: Story = {
     data: DATA,
     dependentAxisLabelValues: [0, 50000, 100000, 150000, 200000, 250000, 300000, 350000],
     independentAxisLabelFormatter: (t: number) => {
-      const date = new Date();
+      const date = new Date('2023-01-01T12:00:00Z');
       date.setMonth(t - 1);
       return date.toLocaleString('en-US', {month: 'short'});
     },
@@ -62,7 +62,7 @@ export const MaxDependentValue: Story = {
           ];
 
           const independentAxisLabelFormatter = (t: number) => {
-            const date = new Date();
+            const date = new Date('2023-01-01T12:00:00Z');
             date.setMonth(t - 1);
             return date.toLocaleString('en-US', {month: 'short'});
           };
@@ -103,7 +103,7 @@ export const MaxDependentValue: Story = {
           ];
 
           const independentAxisLabelFormatter = t => {
-            const date = new Date();
+            const date = new Date('2023-01-01T12:00:00Z');
             date.setMonth(t - 1);
             return date.toLocaleString('en-US', {month: 'short'});
           };
@@ -140,7 +140,7 @@ export const MaxIndependentValue: Story = {
     data: DATA,
     dependentAxisLabelValues: [0, 50000, 100000, 150000, 200000, 250000, 300000, 350000],
     independentAxisLabelFormatter: (t: number) => {
-      const date = new Date();
+      const date = new Date('2023-01-01T12:00:00Z');
       date.setMonth(t - 1);
       return date.toLocaleString('en-US', {month: 'short'});
     },
@@ -184,7 +184,7 @@ export const MaxIndependentValue: Story = {
           ];
 
           const independentAxisLabelFormatter = t => {
-            const date = new Date();
+            const date = new Date('2023-01-01T12:00:00Z');
             date.setMonth(t - 1);
             return date.toLocaleString('en-US', {month: 'short'});
           };

--- a/packages/recipe/src/components/EzField/Documentation/Stories/Regression.stories.tsx
+++ b/packages/recipe/src/components/EzField/Documentation/Stories/Regression.stories.tsx
@@ -1,5 +1,7 @@
 import React, {useEffect, useRef} from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
+import {userEvent, within} from '@storybook/testing-library';
+import {expect} from '@storybook/jest';
 import dayjs from 'dayjs';
 import DefaultMeta from './Default.stories';
 import EzButton from '../../../EzButton';
@@ -198,6 +200,31 @@ export const SelectListLongContent: Story = {
 };
 
 export const SelectListLongContentOpen: Story = {
+  play: ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const firstInput = canvas.getAllByRole('combobox')[0];
+    const secondInput = canvas.getAllByRole('combobox')[1];
+
+    // both inputs should exist
+    expect(canvas.queryAllByDisplayValue(/short value/i)[0]).toBeInTheDocument();
+    expect(
+      canvas.queryAllByDisplayValue(/super ridiculously exaggerated value for an option/i)[0]
+    ).toBeInTheDocument();
+
+    // neither input should be expanded
+    expect(firstInput).toHaveAttribute('aria-expanded', 'false');
+    expect(secondInput).toHaveAttribute('aria-expanded', 'false');
+
+    // the first input should expand when clicked
+    userEvent.click(firstInput);
+    expect(firstInput).toHaveAttribute('aria-expanded', 'true');
+    expect(secondInput).toHaveAttribute('aria-expanded', 'false');
+
+    // the second input should expand when clicked
+    userEvent.click(secondInput);
+    expect(firstInput).toHaveAttribute('aria-expanded', 'false');
+    expect(secondInput).toHaveAttribute('aria-expanded', 'true');
+  },
   render: function SelectListLongContentOpenRender() {
     const selectListLongContentOpenRef = useRef<HTMLDivElement>();
 
@@ -369,6 +396,7 @@ export const AutosuggestLong: Story = {
 };
 
 export const AutosuggestLongContent: Story = {
+  play: SelectListLongContentOpen.play,
   render: function AutosuggestLongContentRender() {
     const autosuggestLongContentRef = useRef<HTMLDivElement>();
 


### PR DESCRIPTION
## What did we change?
- [fix chromatic bugs](https://github.com/ezcater/recipe/commit/2d57f39aec8a859b3782e4c1ee3a205b23fe81d4)

## Why are we doing this?
This PR will hopefully fix all our very annoying chromatic bugs.

For `EzBarChart` there was a discrepancy with how the month was being calculated. Basically, `new Data()` was creating a new date that was today. If "today" was a 29th, 30th, or 31st day, of which none exist in February, the label would assume it's March and change to "Mar". To fix, I hardcoded the example date to the 1st.

For `EzField` select and autosuggest dropdowns, I added interaction tests which will force chromatic to wait until they resolve before taking the snapshot. This should prevent the shifting of the dropdowns that we are seeing.

No changeset needed.