### PR TITLE
Switch colors for EzPageHeader active and inactive tabs to improve UX [FEC-711]

### DIFF
--- a/.changeset/good-colts-yell.md
+++ b/.changeset/good-colts-yell.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzPageHeader

--- a/.changeset/tame-paws-laugh.md
+++ b/.changeset/tame-paws-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+fix: switch colors for EzPageHeader active and inactive tabs to improve UX

--- a/.changeset/tough-donuts-eat.md
+++ b/.changeset/tough-donuts-eat.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: add fill of currentColor to EzIcon for use in playroom

--- a/packages/recipe/src/components/EzIcon/Implementations/EzIconMui/EzIconMui.tsx
+++ b/packages/recipe/src/components/EzIcon/Implementations/EzIconMui/EzIconMui.tsx
@@ -10,7 +10,11 @@ const EzIconMui = forwardRef<Ref, EzIconMuiProps>(
       <SvgIcon
         color={isCommonColor ? undefined : (color as SvgIconColorType)}
         ref={ref}
-        sx={{color: isCommonColor ? color : undefined, fontSize}}
+        sx={{
+          color: isCommonColor ? color : undefined,
+          fill: 'currentColor',
+          fontSize,
+        }}
         titleAccess={title}
         {...props}
       >

--- a/packages/recipe/src/components/EzPageHeader/Documentation/EzPageHeader.mdx
+++ b/packages/recipe/src/components/EzPageHeader/Documentation/EzPageHeader.mdx
@@ -1,4 +1,4 @@
-import {Meta, Unstyled} from '@storybook/blocks';
+import {Controls, Meta, Primary, Unstyled} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -25,6 +25,12 @@ A Page header is used to build the outer structure of a page, including the page
 Features still in consideration include:
 
 - Responsive subnavigation variants (collapsing tabs into menu when space constrained)
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzPageHeader/Documentation/EzPageHeaderExample.tsx
+++ b/packages/recipe/src/components/EzPageHeader/Documentation/EzPageHeaderExample.tsx
@@ -1,0 +1,68 @@
+import React, {useState} from 'react';
+import dedent from 'ts-dedent';
+import {EzCard} from '../../EzCard';
+import {EzPage} from '../../EzPage';
+import {Labelled} from '../../EzLink/EzLink.types';
+import EzPageHeader, {type EzPageHeaderProps} from '../EzPageHeader';
+
+const EzPageHeaderExample = (args?: EzPageHeaderProps) => {
+  const [tabs] = useState([
+    {label: 'All', accessibilityLabel: 'All orders'},
+    {label: 'Accepted', accessibilityLabel: 'Accepted orders'},
+    {label: 'Draft', accessibilityLabel: 'Draft orders'},
+  ]);
+  const [selected, setSelected] = useState<Labelled>(tabs[0]);
+  return (
+    <>
+      <EzPageHeader subnav={{tabs, selected, onChange: setSelected}} {...args} />
+      <EzPage>
+        <EzCard>
+          <div>{selected && selected.accessibilityLabel}</div>
+        </EzCard>
+      </EzPage>
+    </>
+  );
+};
+
+const EzPageHeaderExampleJSX = () => dedent`
+  const {FileDownload, Printer} = require('@ezcater/icons');
+  
+  const [tabs] = useState([
+    {label: 'All', accessibilityLabel: 'All orders'},
+    {label: 'Accepted', accessibilityLabel: 'Accepted orders'},
+    {label: 'Draft', accessibilityLabel: 'Draft orders'},
+  ]);
+  const [selected, setSelected] = useState(tabs[0]);
+  return (
+    <>
+      <EzPageHeader
+        actions={<EzButton>Accept Order</EzButton>}
+        breadcrumb={{
+          label: 'Back to Orders',
+          accessibilityLabel: 'Orders list',
+          onClick: () => {},
+        }}
+        status={<EzChip label="Verified" variant="success" />}
+        subheader={
+          <EzLayout layout="right">
+            <EzButton variant="text" startIcon={<EzIcon icon={Printer} />}>
+              Print
+            </EzButton>
+            <EzButton variant="text" startIcon={<EzIcon icon={FileDownload} />}>
+              Download
+            </EzButton>
+          </EzLayout>
+        }
+        subnav={{tabs, selected, onChange: setSelected}}
+        title="Order # XYZ-123"
+      />
+      <EzPage>
+        <EzCard>
+          <div>{selected && selected.accessibilityLabel}</div>
+        </EzCard>
+      </EzPage>
+    </>
+  );
+`;
+
+export {EzPageHeaderExample, EzPageHeaderExampleJSX};

--- a/packages/recipe/src/components/EzPageHeader/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzPageHeader/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,48 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
-import EzPageHeader from '../../EzPageHeader';
+import {FileDownload, Printer} from '@ezcater/icons';
+import dedent from 'ts-dedent';
+import {EzPageHeaderExample, EzPageHeaderExampleJSX} from '../EzPageHeaderExample';
+import EzButton from '../../../EzButton';
+import EzChip from '../../../EzChip';
+import EzIcon from '../../../EzIcon';
+import EzLayout from '../../../EzLayout';
+import EzPageHeader, {EzPageHeaderProps} from '../../EzPageHeader';
 
 const meta: Meta<typeof EzPageHeader> = {
+  argTypes: {
+    actions: {
+      control: {type: 'node'},
+      description: 'The actions of the page header.',
+      table: {type: {summary: 'ReactNode'}},
+    },
+    breadcrumb: {
+      control: {type: 'object'},
+      description: 'The breadcrumb labelled link of the page header.',
+      table: {type: {summary: 'LabelledLink'}},
+    },
+    status: {
+      control: {type: 'node'},
+      description: '',
+      table: {type: {summary: 'ReactNode'}},
+    },
+    subheader: {
+      control: {type: 'node'},
+      description: 'The subheader actions of the page header.',
+      table: {type: {summary: 'ReactNode'}},
+    },
+    subnav: {
+      control: {type: 'node'},
+      description: 'The subnavigation options of the page header.',
+      table: {type: {summary: 'SubNavProps<TabType>'}},
+    },
+    title: {
+      control: {type: 'text'},
+      description: 'The title of the page header.',
+      table: {type: {summary: 'string'}},
+      type: {name: 'string', required: true},
+    },
+  },
   component: EzPageHeader,
   title: 'Layout/EzPageHeader',
 };
@@ -11,5 +51,34 @@ export default meta;
 type Story = StoryObj<typeof EzPageHeader>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    actions: <EzButton>Accept Order</EzButton>,
+    breadcrumb: {
+      label: 'Back to Orders',
+      accessibilityLabel: 'Orders list',
+      onClick: () => {},
+    },
+    status: <EzChip label="Verified" variant="success" />,
+    subheader: (
+      <EzLayout layout="right">
+        <EzButton variant="text" startIcon={<EzIcon icon={Printer} />}>
+          Print
+        </EzButton>
+        <EzButton variant="text" startIcon={<EzIcon icon={FileDownload} />}>
+          Download
+        </EzButton>
+      </EzLayout>
+    ),
+    title: 'Order # XYZ-123',
+  },
+  parameters: {
+    playroom: {
+      code: dedent`
+        {(() => {
+          ${EzPageHeaderExampleJSX()}
+        })()}
+      `,
+    },
+  },
+  render: (args: EzPageHeaderProps) => EzPageHeaderExample(args),
 };

--- a/packages/recipe/src/components/EzPageHeader/EzPageHeader.tsx
+++ b/packages/recipe/src/components/EzPageHeader/EzPageHeader.tsx
@@ -22,7 +22,7 @@ type SubNavProps<T> = (T extends Link ? Partial<Changeable> : Changeable) & {
 
 type SubNav = SubNavProps<TabType>;
 
-type HeaderProps = {
+export type EzPageHeaderProps = {
   actions?: React.ReactNode;
   breadcrumb?: LabelledLink;
   status?: React.ReactNode;
@@ -85,7 +85,7 @@ const handleKeyDown =
 /**
  * EzPageHeader is used to build the outer structure of a page including the page title and associated actions.
  */
-const EzPageHeader: React.FC<HeaderProps> = ({
+const EzPageHeader: React.FC<EzPageHeaderProps> = ({
   actions,
   breadcrumb,
   status,

--- a/packages/recipe/src/components/EzPageHeader/Tabs.tsx
+++ b/packages/recipe/src/components/EzPageHeader/Tabs.tsx
@@ -29,6 +29,9 @@ const listBase = theme.css({
 const tabBase = theme.css({
   display: 'flex',
   margin: 0,
+  '&& > *, && a': {
+    color: '$tabs-inactive-color',
+  },
   '&& a, && > button': {
     display: 'flex',
     padding: '$tabs-py $tabs-px',

--- a/packages/recipe/src/components/theme.config.ts
+++ b/packages/recipe/src/components/theme.config.ts
@@ -302,7 +302,8 @@ const stitches = createStitches({
 
       // Tabs
       'tabs-outline-color': '$blue600',
-      'tabs-active-color': '$gray700',
+      'tabs-active-color': '$blue600',
+      'tabs-inactive-color': '$gray700',
       'tabs-focus-outline-color': '$blue600',
 
       // EzProgressTracker


### PR DESCRIPTION
## What did we change?
- [add arg types to EzPageHeader](https://github.com/ezcater/recipe/commit/2b535cc116e6cca71174ab702e2e2a98e494ccaf)
- [fix fill color for EzIcon use in playroom](https://github.com/ezcater/recipe/commit/f8bd0c6368db02af382087b3ea092f0eebbd9acf)
- [switch colors for EzPageHeader active and inactive tabs to improve UX](https://github.com/ezcater/recipe/commit/282caeb8268f1a4b76381a070752d6815138e4b3)

## Why are we doing this?
[Request](https://ezcater.atlassian.net/browse/FEC-710)

## Screenshot(s) / Gif(s):
Old:
<img width="830" alt="Screenshot 2023-09-07 at 4 03 26 PM" src="https://github.com/ezcater/recipe/assets/5418735/3208ddff-f859-4d60-811c-2ee832ca0318">
New:
<img width="825" alt="Screenshot 2023-09-07 at 4 03 41 PM" src="https://github.com/ezcater/recipe/assets/5418735/2845d30e-b10f-40c0-880d-b6b9042a7216">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes