### PR TITLE
Fix playroom for EzTable default story [FEC-826]

### DIFF
--- a/.changeset/nine-zebras-provide.md
+++ b/.changeset/nine-zebras-provide.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: fix playroom for EzTable default story

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
@@ -202,6 +202,18 @@ export const Default: Story = {
       code: dedent`
       {(() => {
         const {faCoffee} = require('@fortawesome/free-solid-svg-icons/faCoffee');
+
+        const ActionButtons = (
+          <EzLayout layout="right">
+            <EzButton fontSize="small" variant="text">
+              View
+            </EzButton>
+            <EzButton color="destructive" fontSize="small" variant="text">
+              Delete
+            </EzButton>
+          </EzLayout>
+        );
+        
         return (
           <EzTable
             actions={<EzButton>Add store</EzButton>}


### PR DESCRIPTION
## What did we change?
Fixes a bug in the playroom for `EzTable`.

## Screenshot(s) / Gif(s):
<img width="1703" alt="Screenshot 2023-09-11 at 1 56 11 PM" src="https://github.com/ezcater/recipe/assets/5418735/0b4821e7-ac27-454c-a005-0c9c90c27042">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes