### PR TITLE
FEC-889 bugfix: Pass through the `idPrefix` to the line chart clip component

### DIFF
--- a/.changeset/nice-ants-tease.md
+++ b/.changeset/nice-ants-tease.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: EzLineChart: Pass through the `idPrefix` prop to the line chart clip component to enable apps that use SSR to generate unique IDs for the clip path and avoid a hydration mismatch.

--- a/packages/recipe/src/components/EzLineChart/Implementations/EzLineChartVictory.tsx
+++ b/packages/recipe/src/components/EzLineChart/Implementations/EzLineChartVictory.tsx
@@ -6,6 +6,7 @@ import {
   VictoryScatter,
   VictoryTooltip,
   VictoryVoronoiContainer,
+  VictoryClipContainer,
 } from 'victory';
 import {useTheme} from '@mui/material';
 import {EzLineChartProps, Ref} from '../EzLineChart.types';
@@ -97,7 +98,13 @@ const EzLineChartVictory = forwardRef<Ref, EzLineChartProps>(
             style={independentAxisStyle}
             tickValues={independentAxisLabelValues}
           />
-          <VictoryLine style={lineStyle} data={data} />
+          <VictoryLine
+            style={lineStyle}
+            data={data}
+            groupComponent={
+              <VictoryClipContainer clipId={idPrefix ? `${idPrefix}-clip` : undefined} />
+            }
+          />
           <VictoryScatter
             data={data}
             size={({active}) => (active ? 10 : 1)}


### PR DESCRIPTION
## What did we change?

This passes the `idPrefix` prop, when present, to the `VictoryClipContainer` component (used by victory charts)

## Why are we doing this?

Line charts (and not bar charts) use an svg path to "clip" the contents of the charts for display purposes.

By default Victory charts generates a random ID using an incrementing counter, which breaks apps that use SSR as the number on the server will never match the number on the client.

In https://github.com/ezcater/recipe/pull/985 we added an `idPrefix` prop to our chart components as the container was using the same exact strategy to generate unique element IDs, resulting in the same hydration failures. But we missed that line charts also have this clip component, which also generates a unique ID unless one is given.

## Screenshot(s) / Gif(s):

### Before fix:

<img width="562" alt="Screenshot 2023-09-11 at 2 07 03 PM" src="https://github.com/ezcater/recipe/assets/1180841/2b4b2e9a-0a9f-48ab-8cb5-2ccdb0ceee01">

In this example the chart was given `idPrefix="lineChartExample"`, and we can see the title and desc IDs correctly use that as a base, but the clipPath element has the counter-generated `"victory-clip-1"` ID

### After fix:

<img width="565" alt="Screenshot 2023-09-11 at 2 06 30 PM" src="https://github.com/ezcater/recipe/assets/1180841/40afbe69-40f0-4d90-8038-b983314f6910">

We can now see that the `clipPath` element has an ID of `"lineChartExample-clip"`, matching the other elements (`-desc` and `-title`)

## Checklist

- [ ] Provide test coverage for the changes made
- [x] Create a changeset (`yarn changeset`) with a summary of the changes
 
[Contributing guidelines](https://recipe.ezcater.com/?path=/docs/guides-contributing--docs)