### PR TITLE
Add arg types to EzModal [FEC-825]

### DIFF
--- a/.changeset/bright-ladybugs-tap.md
+++ b/.changeset/bright-ladybugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzModal

--- a/packages/recipe/src/components/EzModal/Documentation/EzModal.mdx
+++ b/packages/recipe/src/components/EzModal/Documentation/EzModal.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/blocks';
+import {Controls, Meta, Primary} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -12,6 +12,12 @@ import * as DefaultStories from './Stories/Default.stories';
 <MigrationAlert component="ez-modal" />
 
 Modals display content in a layer on top of the application. Modals should be used when it's necessary to interrupt the user or ensure their attention is focused on specific information. Modals can also be used when you'd like the user to accomplish a lower-priority action without changing the state of the page they're working in.
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzModal/Documentation/EzModalExample.tsx
+++ b/packages/recipe/src/components/EzModal/Documentation/EzModalExample.tsx
@@ -1,0 +1,52 @@
+import React, {useCallback, useState} from 'react';
+import dedent from 'ts-dedent';
+import {EzContent, EzFooter} from '../../EzContent';
+import EzButton from '../../EzButton';
+import EzLayout from '../../EzLayout';
+import EzModal, {EzModalProps} from '../EzModal';
+
+const EzModalExample = (args?: EzModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleDismiss = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      <EzButton onClick={() => setIsOpen(true)}>Open</EzButton>
+      <EzModal {...args} isOpen={isOpen} onDismiss={handleDismiss}>
+        <EzContent>Are you ready to submit this order?</EzContent>
+        <EzFooter>
+          <EzLayout layout="basic">
+            <EzButton onClick={handleDismiss}>Confirm</EzButton>
+            <EzButton variant="outlined" onClick={handleDismiss}>
+              Cancel
+            </EzButton>
+          </EzLayout>
+        </EzFooter>
+      </EzModal>
+    </>
+  );
+};
+
+const EzModalExampleJSX = (args?: string) => dedent`
+  const [isOpen, setIsOpen] = React.useState(false);
+  const handleDismiss = React.useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      <EzButton onClick={() => setIsOpen(true)}>Open</EzButton>
+      <EzModal isOpen={isOpen} onDismiss={handleDismiss} ${args ? `${args}` : ''}>
+        <EzContent>Are you ready to submit this order?</EzContent>
+        <EzFooter>
+          <EzLayout layout="basic">
+            <EzButton onClick={handleDismiss}>Confirm</EzButton>
+            <EzButton variant="outlined" onClick={handleDismiss}>
+              Cancel
+            </EzButton>
+          </EzLayout>
+        </EzFooter>
+      </EzModal>
+    </>
+  );
+`;
+
+export {EzModalExample, EzModalExampleJSX};

--- a/packages/recipe/src/components/EzModal/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzModal/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,67 @@
-import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
-import EzModal from '../../EzModal';
+import dedent from 'ts-dedent';
+import EzModal, {EzModalProps} from '../../EzModal';
+
+import {EzModalExample, EzModalExampleJSX} from '../EzModalExample';
 
 const meta: Meta<typeof EzModal> = {
+  argTypes: {
+    destructive: {
+      control: {type: 'boolean'},
+      description: 'If true, the modal uses a destructive button.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    dismissLabel: {
+      control: {type: 'text'},
+      description: 'The label of the dismiss button in the modal. Required when using `onDismiss`.',
+      type: {name: 'string'},
+      table: {type: {summary: 'string'}},
+    },
+    headerText: {
+      control: {type: 'text'},
+      description: 'The header text of the modal.',
+      type: {name: 'string'},
+      table: {type: {summary: 'string'}},
+    },
+    isOpen: {
+      control: {type: 'boolean'},
+      description: 'If true, the modal is open.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+      type: {name: 'boolean', required: true},
+    },
+    isSubmitting: {
+      control: {type: 'boolean'},
+      description: 'If true, the modal will render a loading submit button.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    onDismiss: {
+      action: 'dismissed',
+      control: {type: null},
+      description: 'Callback fired when the modal is dismissed. Use with `dismissLabel`.',
+      table: {type: {summary: '(event?: MouseEvent<HTMLButtonElement>) => void'}},
+    },
+    onSubmit: {
+      action: 'submitted',
+      control: {type: null},
+      description: 'Callback fired when the modal is submitted. Use with `submitLabel`.',
+      table: {type: {summary: '(event?: MouseEvent<HTMLButtonElement>) => void'}},
+    },
+    submitLabel: {
+      control: {type: 'text'},
+      description: 'The label of the submit button in the modal. Required when using `onSubmit`.',
+      type: {name: 'string'},
+      table: {type: {summary: 'string'}},
+    },
+  },
   component: EzModal,
   title: 'Feedback/EzModal',
 };
@@ -11,5 +70,17 @@ export default meta;
 type Story = StoryObj<typeof EzModal>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    headerText: 'Submit your order',
+  },
+  parameters: {
+    playroom: {
+      code: dedent`
+        {(() => {
+          ${EzModalExampleJSX('headerText="Submit your order"')}
+        })()}
+      `,
+    },
+  },
+  render: (args: EzModalProps) => EzModalExample(args),
 };

--- a/packages/recipe/src/components/EzModal/EzModal.tsx
+++ b/packages/recipe/src/components/EzModal/EzModal.tsx
@@ -70,8 +70,7 @@ const icon = theme.css({
   '&&': {margin: '8px'},
 });
 
-type Props = {
-  appElement?: string;
+export type EzModalProps = {
   children?: ReactNode;
   destructive?: boolean;
   dismissLabel?: string;
@@ -99,7 +98,7 @@ const useDialog = ({onDismiss}) => ({
   },
 });
 
-const EzModal: React.FC<Props> = ({
+const EzModal: React.FC<EzModalProps> = ({
   children,
   headerText,
   destructive,


### PR DESCRIPTION
## What did we change?
- [add arg types to EzModal](https://github.com/ezcater/recipe/commit/2aeefcb592bf84a26b1287c582173dee304457c5)

## Why are we doing this?
Part of our migration to storybook docs.

## Screenshot(s) / Gif(s):
<img width="1701" alt="Screenshot 2023-09-14 at 2 48 44 PM" src="https://github.com/ezcater/recipe/assets/5418735/e5f51d67-86de-4421-a791-1608c3a5cf52">
<img width="1703" alt="Screenshot 2023-09-14 at 2 48 57 PM" src="https://github.com/ezcater/recipe/assets/5418735/cab879c2-ce79-499c-b871-5e65db5f6fc8">
<img width="1704" alt="Screenshot 2023-09-14 at 2 54 51 PM" src="https://github.com/ezcater/recipe/assets/5418735/6f5c7ec0-20c5-481b-a251-e81cabd391d9">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes