### PR TITLE
Add arg types to EzTooltip [FEC-841]

### DIFF
--- a/.changeset/grumpy-impalas-suffer.md
+++ b/.changeset/grumpy-impalas-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzTooltip

--- a/packages/recipe/src/components/EzTooltip/Documentation/EzTooltip.mdx
+++ b/packages/recipe/src/components/EzTooltip/Documentation/EzTooltip.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/blocks';
+import {Controls, Meta, Primary} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -12,6 +12,12 @@ import * as DefaultStories from './Stories/Default.stories';
 <MigrationAlert component="ez-tooltip" />
 
 A tooltip is a floating label for displaying helpful contextual messages. When the user's mouse or focus rests on an element, a non-interactive popup is displayed near it.
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzTooltip/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzTooltip/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,32 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
-import EzTooltip from '../../EzTooltip';
+import dedent from 'ts-dedent';
+import EzTooltip, {EzTooltipProps} from '../../EzTooltip';
 
 const meta: Meta<typeof EzTooltip> = {
+  argTypes: {
+    message: {
+      control: {type: 'text'},
+      description: 'The message of the tooltip. Use `\\n` to create multiple lines.',
+      table: {type: {summary: 'string'}},
+      type: {name: 'string', required: true},
+    },
+    onShowTooltip: {
+      action: 'tooltip shown',
+      control: {type: null},
+      description: 'Callback fired when the tooltip is shown.',
+      table: {type: {summary: '() => void'}},
+    },
+    position: {
+      control: {type: 'select'},
+      description: 'The position of the tooltip relative to its child node.',
+      options: ['horizontal', 'vertical'],
+      table: {
+        defaultValue: {summary: 'vertical'},
+        type: {summary: 'horizontal | vertical'},
+      },
+    },
+  },
   component: EzTooltip,
   title: 'Feedback/EzTooltip',
 };
@@ -11,5 +35,23 @@ export default meta;
 type Story = StoryObj<typeof EzTooltip>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    message: 'This is a tooltip!',
+    position: 'vertical',
+  },
+  parameters: {
+    layout: 'centered',
+    playroom: {
+      code: dedent`
+        <EzTooltip message="This is a tooltip!">
+          <span>Hover over me</span>
+        </EzTooltip>
+      `,
+    },
+  },
+  render: (args: EzTooltipProps) => (
+    <EzTooltip {...args}>
+      <span>Hover over me</span>
+    </EzTooltip>
+  ),
 };

--- a/packages/recipe/src/components/EzTooltip/EzTooltip.tsx
+++ b/packages/recipe/src/components/EzTooltip/EzTooltip.tsx
@@ -1,15 +1,23 @@
-import React, {useState, useRef, ReactElement, useEffect} from 'react';
+import React, {
+  cloneElement,
+  FC,
+  type HTMLAttributes,
+  type ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import theme from '../theme.config';
 import {useUniqueId} from '../../utils/hooks';
 import EzPopover from '../EzPopover';
 import {domProps} from '../../utils';
 
-type Props = {
+export type EzTooltipProps = {
   position?: 'vertical' | 'horizontal';
   message: string;
   children: ReactElement;
   onShowTooltip?: () => void;
-} & React.HTMLAttributes<any>;
+} & HTMLAttributes<any>;
 
 const tooltip = theme.css({
   position: 'relative',
@@ -53,7 +61,7 @@ const arrowPosition = theme.css({
 
 const reset = theme.css({my: 0});
 
-const EzTooltip: React.FC<Props> = ({children, message, position, onShowTooltip, ...rest}) => {
+const EzTooltip: FC<EzTooltipProps> = ({children, message, position, onShowTooltip, ...rest}) => {
   const id = useUniqueId();
   const targetRef = useRef(null);
   const [isHovered, setIsHovered] = useState(false);
@@ -87,7 +95,7 @@ const EzTooltip: React.FC<Props> = ({children, message, position, onShowTooltip,
 
   return (
     <>
-      {React.cloneElement(child, childProps)}
+      {cloneElement(child, childProps)}
 
       {showTooltip && (
         <EzPopover


### PR DESCRIPTION
## What did we change?
- [add arg types to EzTooltip](https://github.com/ezcater/recipe/commit/a84f7a911bf0c7849bca3a1b8002dbb43b92e2e9)

## Why are we doing this?
Part of our migration to storybook docs.

## Screenshot(s) / Gif(s):
<img width="1703" alt="Screenshot 2023-09-15 at 11 00 09 AM" src="https://github.com/ezcater/recipe/assets/5418735/d6b3e4b0-e09b-4f72-866d-1b504c080a9b">
<img width="1701" alt="Screenshot 2023-09-15 at 10 57 55 AM" src="https://github.com/ezcater/recipe/assets/5418735/9412955f-5e5d-4b7b-bd90-597937053df5">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes