### PR TITLE
Add arg types to EzPage [FEC-828]

### DIFF
--- a/.changeset/plenty-cycles-visit.md
+++ b/.changeset/plenty-cycles-visit.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzPage

--- a/packages/recipe/src/components/EzPage/Documentation/EzPage.mdx
+++ b/packages/recipe/src/components/EzPage/Documentation/EzPage.mdx
@@ -1,4 +1,4 @@
-import {Meta} from '@storybook/blocks';
+import {Controls, Meta, Primary} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -14,6 +14,12 @@ import * as DefaultStories from './Stories/Default.stories';
 EzPage is the main content container for a page. The Page component controls the horizontal margins of the content area, as well as the vertical spacing between content.
 
 These examples mostly use Cards, but you can put multiple kinds of content in Page.
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzPage/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzPage/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,21 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
-import EzPage from '../../EzPage';
+import dedent from 'ts-dedent';
+import {EzCard} from '../../../EzCard';
+import EzPage, {EzPageProps} from '../../EzPage';
 
 const meta: Meta<typeof EzPage> = {
+  argTypes: {
+    backgroundColor: {
+      control: {type: 'select'},
+      description: 'The background color of the page.',
+      options: ['gray', 'white'],
+      table: {
+        defaultValue: {summary: 'gray'},
+        type: {summary: 'string'},
+      },
+    },
+  },
   component: EzPage,
   title: 'Layout/EzPage',
 };
@@ -11,5 +24,29 @@ export default meta;
 type Story = StoryObj<typeof EzPage>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    backgroundColor: 'gray',
+  },
+  parameters: {
+    playroom: {
+      code: dedent`
+        <EzPage>
+          <EzCard title="Card">Content</EzCard>
+          <EzCard title="Card">Content</EzCard>
+          <EzCard title="Table">
+            This example is really a card, but you can put tables and other content in EzPage too.
+          </EzCard>
+        </EzPage>
+      `,
+    },
+  },
+  render: (args: EzPageProps) => (
+    <EzPage {...args}>
+      <EzCard title="Card">Content</EzCard>
+      <EzCard title="Card">Content</EzCard>
+      <EzCard title="Table">
+        This example is really a card, but you can put tables and other content in EzPage too.
+      </EzCard>
+    </EzPage>
+  ),
 };

--- a/packages/recipe/src/components/EzPage/EzPage.tsx
+++ b/packages/recipe/src/components/EzPage/EzPage.tsx
@@ -48,7 +48,7 @@ const pageWrapper = theme.css({
   },
 });
 
-type Props = {
+export type EzPageProps = {
   backgroundColor?: 'white' | 'gray';
   children: React.ReactNode;
 };
@@ -75,7 +75,7 @@ export const usePageSection = type => {
   return ref.current;
 };
 
-const EzPage: React.FC<Props> = ({children, backgroundColor}) => {
+const EzPage: React.FC<EzPageProps> = ({children, backgroundColor}) => {
   const sectionsCounter = useRef(0);
   return (
     <SectionContext.Provider value={sectionsCounter}>


### PR DESCRIPTION
## What did we change?
- [add arg types to EzPage](https://github.com/ezcater/recipe/commit/9b79a1e3e438f660e93a1c2927ad47dcfc239eb0)

## Why are we doing this?
Part of our migration to storybook docs.

## Screenshot(s) / Gif(s):
<img width="1702" alt="Screenshot 2023-09-15 at 2 15 25 PM" src="https://github.com/ezcater/recipe/assets/5418735/29af2ec5-36b7-4b58-859b-c36ebfa25db0">
<img width="1703" alt="Screenshot 2023-09-15 at 2 15 09 PM" src="https://github.com/ezcater/recipe/assets/5418735/3978d38a-bc8d-4006-8451-462218108be3">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes