### PR TITLE
Add Box and Stack MUI components to playroom [FEC-902]

### DIFF
--- a/.changeset/honest-olives-travel.md
+++ b/.changeset/honest-olives-travel.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add Box and Stack MUI components to playroom

--- a/packages/recipe/playroom/useScope.js
+++ b/packages/recipe/playroom/useScope.js
@@ -1,5 +1,6 @@
 import {useRef, useEffect, useState} from 'react';
 import {Link, NavLink, BrowserRouter, StaticRouter, Route} from 'react-router-dom';
+import {Box, Stack} from '@mui/material';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
@@ -30,6 +31,8 @@ import Placeholder from '../src/components/utils/Placeholder';
 export default () => ({
   withPrefix: path => `https://recipe.ezcater.com/playroom${path}`,
   Placeholder,
+  Box,
+  Stack,
   useRef,
   useEffect,
   useState,


### PR DESCRIPTION
## What did we change?
- [add Box and Stack MUI components to playroom](https://github.com/ezcater/recipe/commit/4cdac75e9def24ad67007fc959c4f1f3d8466f5c)

## Why are we doing this?
Request [[FEC-896](https://ezcater.atlassian.net/browse/FEC-896)].

We want to discourage inline styles when creating examples in the playroom. This allows us to use MUI's [Box](https://mui.com/material-ui/react-box/) and [Stack](https://mui.com/material-ui/react-stack/) container components that support MUI's [system properties](https://mui.com/system/properties/).

## Screenshot(s) / Gif(s):
<img width="1704" alt="Screenshot 2023-09-22 at 3 30 54 PM" src="https://github.com/ezcater/recipe/assets/5418735/9e6cd979-da84-43b5-ba20-83fb051dfc40">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes

[FEC-896]: https://ezcater.atlassian.net/browse/FEC-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ