### PR TITLE
Add arg types and forward ref to EzPopover & fix typescript bug [FEC-830] [FEC-592] [FEC-900]

### DIFF
--- a/.changeset/brave-teachers-drive.md
+++ b/.changeset/brave-teachers-drive.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: add forwardRef to EzPopover

--- a/.changeset/pink-humans-hang.md
+++ b/.changeset/pink-humans-hang.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+docs: add arg types to EzPopover

--- a/.changeset/weak-pumas-explain.md
+++ b/.changeset/weak-pumas-explain.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: fix EzPopover typescript error with shouldCloseOnBlur which must be used with onClose

--- a/packages/recipe/src/components/EzPopover/Documentation/EzPopover.mdx
+++ b/packages/recipe/src/components/EzPopover/Documentation/EzPopover.mdx
@@ -1,4 +1,4 @@
-import {Meta, Unstyled} from '@storybook/blocks';
+import {Controls, Meta, Primary, Unstyled} from '@storybook/blocks';
 import MigrationAlert from '../../../../docs/components/MigrationAlert';
 import RelatedComponents from '../../../../docs/components/RelatedComponents';
 import TableOfContents from '../../../../docs/components/TableOfContents';
@@ -21,6 +21,12 @@ Popover is a non-modal dialog that floats relative to another element. It's comm
     use="info"
   />
 </Unstyled>
+
+<Primary />
+
+## Props
+
+<Controls of={DefaultStories.Default} sort="requiredFirst" />
 
 ## Best practices
 

--- a/packages/recipe/src/components/EzPopover/Documentation/EzPopoverExample.tsx
+++ b/packages/recipe/src/components/EzPopover/Documentation/EzPopoverExample.tsx
@@ -1,0 +1,53 @@
+import React, {useState, useRef} from 'react';
+import dedent from 'ts-dedent';
+import {EzCard} from '../../EzCard';
+import EzButton from '../../EzButton';
+import EzPopover, {EzPopoverProps} from '../EzPopover';
+
+const EzPopoverExample = (args?: EzPopoverProps) => {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <>
+      <EzButton
+        ref={ref}
+        onClick={() => setVisible(!visible)}
+        onKeyDown={(event: {key: string}) => event.key === 'Escape' && setVisible(false)}
+      >
+        Toggle popover
+      </EzButton>
+
+      {visible && (
+        <EzPopover {...args} targetRef={ref} onClose={() => setVisible(false)}>
+          <EzCard>Hi!</EzCard>
+        </EzPopover>
+      )}
+    </>
+  );
+};
+
+const EzPopoverExampleJSX = (args?: string) => dedent`
+  const ref = React.useRef(null);
+  const [visible, setVisible] = React.useState(false);
+
+  return (
+    <>
+      <EzButton
+        ref={ref}
+        onClick={() => setVisible(!visible)}
+        onKeyDown={event => event.key === 'Escape' && setVisible(false)}
+      >
+        Toggle popover
+      </EzButton>
+
+      {visible && (
+        <EzPopover targetRef={ref} onClose={() => setVisible(false)} ${args ? `${args}` : ''}>
+          <EzCard>Hi!</EzCard>
+        </EzPopover>
+      )}
+    </>
+  );
+`;
+
+export {EzPopoverExample, EzPopoverExampleJSX};

--- a/packages/recipe/src/components/EzPopover/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzPopover/Documentation/Stories/Default.stories.tsx
@@ -1,8 +1,76 @@
-import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
-import EzPopover from '../../EzPopover';
+import dedent from 'ts-dedent';
+import EzPopover, {EzPopoverProps} from '../../EzPopover';
+import {EzPopoverExample, EzPopoverExampleJSX} from '../EzPopoverExample';
 
 const meta: Meta<typeof EzPopover> = {
+  argTypes: {
+    matchWidth: {
+      control: {type: 'boolean'},
+      description: 'If true, the popover will match the width of the target element.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    onClose: {
+      action: 'closed',
+      control: {type: 'function'},
+      description: 'Callback fired when the popover is closed.',
+      table: {type: {summary: '() => void'}},
+    },
+    placement: {
+      control: {type: 'select'},
+      description: 'The location of the arrow.',
+      options: [
+        'auto',
+        'auto-start',
+        'auto-end',
+        'top',
+        'bottom',
+        'right',
+        'left',
+        'top-start',
+        'top-end',
+        'bottom-start',
+        'bottom-end',
+        'right-start',
+        'right-end',
+        'left-start',
+        'left-end',
+      ],
+      table: {
+        defaultValue: {summary: 'bottom'},
+        type: {
+          summary:
+            'auto | auto-start | auto-end | top | bottom | right | left | top-start | top-end | bottom-start | bottom-end | right-start | right-end | left-start | left-end',
+        },
+      },
+    },
+    shouldCloseOnBlur: {
+      control: {type: 'boolean'},
+      description:
+        'If true, popper will call `onClose` when the user clicks away from the popover.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    showArrow: {
+      control: {type: 'boolean'},
+      description: 'If true, popper will show an arrow pointing to the referenced element.',
+      table: {
+        defaultValue: {summary: false},
+        type: {summary: 'boolean'},
+      },
+    },
+    targetRef: {
+      control: {type: 'object'},
+      description: 'The reference to the element that the popover should position next to.',
+      table: {type: {summary: 'RefObject<HTMLElement>'}},
+      type: {name: 'other', value: 'RefObject<HTMLElement>', required: true},
+    },
+  },
   component: EzPopover,
   title: 'Feedback/EzPopover',
 };
@@ -11,5 +79,22 @@ export default meta;
 type Story = StoryObj<typeof EzPopover>;
 
 export const Default: Story = {
-  render: () => <div>Coming soon...</div>,
+  args: {
+    matchWidth: false,
+    placement: 'bottom',
+    shouldCloseOnBlur: false,
+    showArrow: false,
+  },
+  parameters: {
+    docs: {source: {code: EzPopoverExampleJSX()}},
+    layout: 'centered',
+    playroom: {
+      code: dedent`
+        {(() => {
+          ${EzPopoverExampleJSX()}
+        })()}
+      `,
+    },
+  },
+  render: (args: EzPopoverProps) => EzPopoverExample(args),
 };

--- a/packages/recipe/src/components/EzPopover/EzPopover.tsx
+++ b/packages/recipe/src/components/EzPopover/EzPopover.tsx
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import React from 'react';
+import React, {FC, type HTMLAttributes, type RefObject, useEffect, useRef} from 'react';
 import {Placement, Modifier} from '@popperjs/core';
 import EzPortal, {PortalContext} from '../EzPortal';
 import theme from '../theme.config';
@@ -8,27 +8,27 @@ import {useCloseOnBlur} from './useCloseOnBlur';
 import FocusScope from '../utils/FocusScope';
 import {clsx} from '../../utils';
 
-type Props = {
-  targetRef: React.RefObject<HTMLElement>;
-  placement?: Placement;
-  matchWidth?: boolean;
-  showArrow?: boolean;
-  shouldCloseOnBlur?: boolean;
-  onClose?: () => void;
+export type EzPopoverProps = {
   classNameSuffix?: string;
-} & React.HTMLAttributes<any>;
+  matchWidth?: boolean;
+  onClose?: () => void;
+  placement?: Placement;
+  shouldCloseOnBlur?: boolean;
+  showArrow?: boolean;
+  targetRef: RefObject<HTMLElement>;
+} & HTMLAttributes<any>;
 
 const popperStyle = theme.css({
   zIndex: '$popover-z', // this is hard-coded in theme.config.ts for now, but we should really pull it in from mui when we convert popovers to mui
 });
 
-const EzPopover: React.FC<Props> = props => (
+const EzPopover: FC<EzPopoverProps> = props => (
   <EzPortal>
     <PopoverImpl {...props} />
   </EzPortal>
 );
 
-const PopoverImpl: React.FC<Props> = ({
+const PopoverImpl: FC<EzPopoverProps> = ({
   targetRef,
   placement = 'bottom',
   matchWidth = false,
@@ -63,9 +63,9 @@ const PopoverImpl: React.FC<Props> = ({
 
   useCloseOnBlur({shouldCloseOnBlur, onClose, refs: [targetRef, popper]});
 
-  const scopeRef = React.useRef();
+  const scopeRef = useRef();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const triggerEl = targetRef.current;
     const focusScope: any = scopeRef.current;
 

--- a/packages/recipe/src/components/EzPopover/EzPopover.tsx
+++ b/packages/recipe/src/components/EzPopover/EzPopover.tsx
@@ -1,12 +1,14 @@
 /* istanbul ignore file */
-import React, {FC, type HTMLAttributes, type RefObject, useEffect, useRef} from 'react';
+import React, {forwardRef, type HTMLAttributes, type RefObject, useEffect, useRef} from 'react';
 import {Placement, Modifier} from '@popperjs/core';
 import EzPortal, {PortalContext} from '../EzPortal';
 import theme from '../theme.config';
 import {usePopper} from '../../utils/hooks';
 import {useCloseOnBlur} from './useCloseOnBlur';
 import FocusScope from '../utils/FocusScope';
-import {clsx} from '../../utils';
+import {clsx, mergeRefs} from '../../utils';
+
+export type Ref = HTMLDivElement;
 
 export type EzPopoverProps = {
   classNameSuffix?: string;
@@ -22,86 +24,94 @@ const popperStyle = theme.css({
   zIndex: '$popover-z', // this is hard-coded in theme.config.ts for now, but we should really pull it in from mui when we convert popovers to mui
 });
 
-const EzPopover: FC<EzPopoverProps> = props => (
+const EzPopover = forwardRef<Ref, EzPopoverProps>((props, ref) => (
   <EzPortal>
-    <PopoverImpl {...props} />
+    <EzPopoverImpl ref={ref} {...props} />
   </EzPortal>
+));
+
+const EzPopoverImpl = forwardRef<Ref, EzPopoverProps>(
+  (
+    {
+      targetRef,
+      placement = 'bottom',
+      matchWidth = false,
+      showArrow = false,
+      shouldCloseOnBlur = false,
+      onClose,
+      children,
+      classNameSuffix,
+      ...rest
+    },
+    ref
+  ) => {
+    const modifiers: Array<Partial<Modifier<any, any>>> = [
+      {name: 'offset', options: {offset: [0, 5]}},
+    ];
+
+    if (matchWidth) {
+      modifiers.push({
+        name: 'matchWidth',
+        enabled: true,
+        fn: ({state}) => {
+          // eslint-disable-next-line no-param-reassign
+          state.styles.popper.width = `${state.rects.reference.width}px`;
+        },
+        phase: 'beforeWrite',
+        requires: ['computeStyles'],
+      });
+    }
+
+    if (showArrow) modifiers.push({name: 'arrow', enabled: true, options: {padding: 5}});
+
+    const {popper, reference} = usePopper({placement, modifiers});
+    reference.current = targetRef.current;
+
+    useCloseOnBlur({shouldCloseOnBlur, onClose, refs: [targetRef, popper]});
+
+    const scopeRef = useRef();
+
+    useEffect(() => {
+      const triggerEl = targetRef.current;
+      const focusScope: any = scopeRef.current;
+
+      const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+
+        // intercept tabbing from trigger to move focus into the popover
+        e.preventDefault();
+        focusScope.focusFirstInScope();
+      };
+
+      triggerEl.addEventListener('keydown', onKeyDown, true);
+
+      return () => {
+        triggerEl.removeEventListener('keydown', onKeyDown, true);
+      };
+    }, [targetRef]);
+
+    return (
+      <div
+        data-popper-placement
+        ref={mergeRefs([popper, ref])}
+        {...rest}
+        className={clsx(
+          popperStyle(),
+          'EzPopover',
+          classNameSuffix && `EzPopover-${classNameSuffix}`
+        )}
+      >
+        <PortalContext.Provider value={popper}>
+          <FocusScope restoreFocus ref={scopeRef}>
+            {children}
+          </FocusScope>
+        </PortalContext.Provider>
+      </div>
+    );
+  }
 );
 
-const PopoverImpl: FC<EzPopoverProps> = ({
-  targetRef,
-  placement = 'bottom',
-  matchWidth = false,
-  showArrow = false,
-  shouldCloseOnBlur = false,
-  onClose,
-  children,
-  classNameSuffix,
-  ...rest
-}) => {
-  const modifiers: Array<Partial<Modifier<any, any>>> = [
-    {name: 'offset', options: {offset: [0, 5]}},
-  ];
-
-  if (matchWidth) {
-    modifiers.push({
-      name: 'matchWidth',
-      enabled: true,
-      fn: ({state}) => {
-        // eslint-disable-next-line no-param-reassign
-        state.styles.popper.width = `${state.rects.reference.width}px`;
-      },
-      phase: 'beforeWrite',
-      requires: ['computeStyles'],
-    });
-  }
-
-  if (showArrow) modifiers.push({name: 'arrow', enabled: true, options: {padding: 5}});
-
-  const {popper, reference} = usePopper({placement, modifiers});
-  reference.current = targetRef.current;
-
-  useCloseOnBlur({shouldCloseOnBlur, onClose, refs: [targetRef, popper]});
-
-  const scopeRef = useRef();
-
-  useEffect(() => {
-    const triggerEl = targetRef.current;
-    const focusScope: any = scopeRef.current;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
-
-      // intercept tabbing from trigger to move focus into the popover
-      e.preventDefault();
-      focusScope.focusFirstInScope();
-    };
-
-    triggerEl.addEventListener('keydown', onKeyDown, true);
-
-    return () => {
-      triggerEl.removeEventListener('keydown', onKeyDown, true);
-    };
-  }, [targetRef]);
-
-  return (
-    <div
-      data-popper-placement
-      ref={popper as any}
-      {...rest}
-      className={clsx(
-        popperStyle(),
-        'EzPopover',
-        classNameSuffix && `EzPopover-${classNameSuffix}`
-      )}
-    >
-      <PortalContext.Provider value={popper}>
-        <FocusScope restoreFocus ref={scopeRef}>
-          {children}
-        </FocusScope>
-      </PortalContext.Provider>
-    </div>
-  );
-};
+EzPopover.displayName = 'EzPopover';
+EzPopoverImpl.displayName = 'EzPopoverImpl';
 
 export default EzPopover;

--- a/packages/recipe/src/components/EzPopover/__tests__/EzPopover.test.tsx
+++ b/packages/recipe/src/components/EzPopover/__tests__/EzPopover.test.tsx
@@ -5,9 +5,6 @@ import EzPopover from '../EzPopover';
 import EzField from '../../EzField';
 import {useCloseOnBlur} from '../useCloseOnBlur';
 
-// Not sure why this path is two levels deep instead of one, but 🤷‍♂️
-jest.unmock('../../EzPopover');
-
 describe('EzPopover', () => {
   describe('shouldCloseOnBlur', () => {
     it('should call onClose only when clicking outside', () => {
@@ -173,6 +170,21 @@ describe('EzPopover', () => {
     // tab back up to the original input
     await user.tab({shift: true});
     expect(document.activeElement).toBe(inputBefore);
+  });
+
+  it('forwards refs', () => {
+    const ref = {current: undefined};
+    const {rerender} = render(
+      <EzPopover targetRef={{current: document.createElement('div')}} ref={ref}>
+        <div>Hi!</div>
+      </EzPopover>
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toBeInTheDocument();
+
+    rerender(<></>);
+    expect(ref.current).toBeNull();
   });
 
   it('should meet accessibility guidelines', async () => {

--- a/packages/recipe/src/components/EzPopover/index.tsx
+++ b/packages/recipe/src/components/EzPopover/index.tsx
@@ -1,3 +1,1 @@
-import EzPopover from './EzPopover';
-
-export default EzPopover;
+export {default} from './EzPopover';

--- a/packages/recipe/src/components/EzPopover/useCloseOnBlur.tsx
+++ b/packages/recipe/src/components/EzPopover/useCloseOnBlur.tsx
@@ -1,7 +1,9 @@
 import {useOnClickOutside, useOnFocusOutside} from '../../utils/hooks';
 
 export function useCloseOnBlur(options): void {
-  const onBlur = () => options.shouldCloseOnBlur && options.onClose();
+  const onBlur = () => {
+    if (options.shouldCloseOnBlur && options.onClose) options.onClose();
+  };
   useOnClickOutside(onBlur, options.refs);
   useOnFocusOutside(onBlur, options.refs);
 }

--- a/packages/recipe/src/utils/__tests__/mergeRefs.test.tsx
+++ b/packages/recipe/src/utils/__tests__/mergeRefs.test.tsx
@@ -1,0 +1,32 @@
+import React, {forwardRef} from 'react';
+import {render} from '@testing-library/react';
+import mergeRefs from '../mergeRefs';
+
+describe('mergeRefs', () => {
+  const TestComponent = forwardRef(function TestComponent(_, ref) {
+    React.useImperativeHandle(ref, () => 'testValue');
+    return null;
+  });
+
+  it('combines refs and reacts correctly to the component lifecycle', () => {
+    const refAsFunc = jest.fn();
+    const refAsObj = {current: undefined};
+    const Example: React.FC<{visible: boolean}> = ({visible}) => {
+      return visible ? <TestComponent ref={mergeRefs([refAsObj, refAsFunc])} /> : null;
+    };
+
+    // on mount the ref value gets set to "testValue"
+    // both the function and the object ref should be notified
+    const {rerender} = render(<Example visible />);
+    expect(refAsFunc).toHaveBeenCalledTimes(1);
+    expect(refAsFunc).toHaveBeenCalledWith('testValue');
+    expect(refAsObj.current).toBe('testValue');
+
+    // when the component dismounts, the ref value gets unset
+    // both the function and the object ref should be notified
+    rerender(<Example visible={false} />);
+    expect(refAsFunc).toHaveBeenCalledTimes(2);
+    expect(refAsFunc).toHaveBeenCalledWith(null);
+    expect(refAsObj.current).toBe(null);
+  });
+});

--- a/packages/recipe/src/utils/index.ts
+++ b/packages/recipe/src/utils/index.ts
@@ -3,5 +3,6 @@ import filterValidProps from './filterValidProps';
 export {filterValidProps};
 export {wrapEvent, wrapEvents} from './wrapEvent';
 export {mergeProps, clsx} from './mergeProps';
+export {default as mergeRefs} from './mergeRefs';
 export {domProps} from './domProps';
 export {default as responsiveProps} from './responsiveProps';

--- a/packages/recipe/src/utils/mergeRefs.ts
+++ b/packages/recipe/src/utils/mergeRefs.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function mergeRefs<T = any>(
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>
+): React.RefCallback<T> {
+  return value => {
+    refs.forEach(ref => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref != null) {
+        // eslint-disable-next-line no-param-reassign
+        (ref as React.MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+}


### PR DESCRIPTION
## What did we change?
- [add arg types to EzPopover](https://github.com/ezcater/recipe/commit/431e09d3103884711d56c9ebbb1bd3c25349749c)
- [fix EzPopover typescript error with shouldCloseOnBlur which must be used with onClose](https://github.com/ezcater/recipe/commit/c276981f773203a35c070e0aed0400e2626c3b6e) 
- [add forwardRef to EzPopover](https://github.com/ezcater/recipe/commit/c3487f4a47ed23cb0d0d772b75aafa080edaebfb)

## Why are we doing this?
Request [[FEC-891](https://ezcater.atlassian.net/browse/FEC-891)].

## Screenshot(s) / Gif(s):
<img width="1704" alt="Screenshot 2023-09-26 at 8 55 29 AM" src="https://github.com/ezcater/recipe/assets/5418735/606ece02-2051-430f-8272-8d95b6ab0431">
<img width="1702" alt="Screenshot 2023-09-26 at 8 55 53 AM" src="https://github.com/ezcater/recipe/assets/5418735/ffb5e967-5f3d-49f6-b586-a0f71cd1dfcb">

## Checklist

- [x] Provide test coverage for the changes made
- [x] Create a changeset (`yarn changeset`) with a summary of the changes

[FEC-891]: https://ezcater.atlassian.net/browse/FEC-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ