### PR TITLE
Add `numericPadded` option to `EzTable` columns adding additional right padding [FEC-906]

### DIFF
--- a/.changeset/tame-deers-report.md
+++ b/.changeset/tame-deers-report.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: add numericPadded option to EzTable columns adding additional right padding

--- a/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
+++ b/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
@@ -80,6 +80,7 @@ Use simple tables whenever the tabular data is directly related to the preceding
   - `heading` (required string): The heading of the column.
   - `icon` (ReactNode | ComponentType): An optional icon appending the heading of the column.
   - `numeric` (boolean): If true, the column is right aligned.
+  - `numericPadded` (boolean): If true, the column is right aligned with a right padding of `32px`.
   - `width` (number): The width of the column.
   - `component` (ReactNode | ComponentType): See [Interactive cells](#interactive-cells).
   - `sortable` (boolean): See [Sortable tables](#sortable).

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
@@ -39,6 +39,7 @@ const meta: Meta<typeof EzTable> = {
               icon?: ReactNode | ComponentType;
               key?: string;
               numeric?: boolean;
+              numericPadded?: boolean;
               sortable?: boolean;
               width?: number;
             ]

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Regression.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Regression.stories.tsx
@@ -205,3 +205,33 @@ const HorizontalScrollExample = () => {
 export const HorizontalScroll: Story = {
   render: () => HorizontalScrollExample(),
 };
+
+export const NumericPadded: Story = {
+  render: () => (
+    <EzTable
+      columns={[
+        {heading: 'Store name', key: 'store'},
+        {
+          heading: 'Total sales',
+          key: 'total',
+          numeric: true,
+        },
+        {heading: 'Average order value', key: 'average', numericPadded: true},
+        {heading: 'Status', key: 'status'},
+      ]}
+      items={[
+        {id: '#001', store: 'Ten Forward', total: 23267, average: 327.79, status: 'Open'},
+        {id: '#002', store: "Sisko's Kitchen", total: 22788, average: 367.55, status: 'Open'},
+        {id: '#003', store: "Quark's Bar", total: 12392, average: 210.21, status: 'Closed'},
+        {id: '#004', store: 'Betazoid Bakery', total: 13085, average: 184.29, status: 'Open'},
+      ]}
+      selection={{
+        isRowSelected: () => true,
+        onBulkSelectClick: () => {},
+        onRowSelectClick: () => {},
+      }}
+      subtitle="Compared to the same period last year"
+      title="All Stores"
+    />
+  ),
+};

--- a/packages/recipe/src/components/EzTable/EzTable.tsx
+++ b/packages/recipe/src/components/EzTable/EzTable.tsx
@@ -63,6 +63,11 @@ const numericCell = theme.css({
   textAlign: 'right',
 });
 
+const numericPaddedCell = theme.css({
+  textAlign: 'right',
+  paddingRight: '32px',
+});
+
 const header = theme.css({
   fontWeight: '$table-heading',
   fontSize: '$table-heading',
@@ -197,6 +202,7 @@ const SortIcon = ({direction, isSorted}) => (
 type ThProps = {
   children: any;
   numeric?: boolean;
+  numericPadded?: boolean;
   isSelection?: boolean;
   isSortableColumn?: boolean;
   sorted?: boolean;
@@ -209,6 +215,7 @@ const Th: FC<ThProps> = ({
   isSelection,
   isSortableColumn,
   numeric,
+  numericPadded,
   onClick,
   sorted,
   width,
@@ -218,6 +225,7 @@ const Th: FC<ThProps> = ({
     className={clsx(
       isSelection ? checkboxCell() : cell(),
       numeric && numericCell(),
+      numericPadded && numericPaddedCell(),
       header(),
       isSortableColumn && sortableColumn(),
       sorted && sortedCell()
@@ -254,11 +262,12 @@ const Thead = ({selectable}) => {
           </Th>
         )}
         {columns.map((column, cellIndex) => {
-          const {sortable, heading, numeric, icon, width} = column;
+          const {sortable, heading, numeric, numericPadded, icon, width} = column;
           return (
             <Th
               key={column.key || cellIndex}
               numeric={numeric}
+              numericPadded={numericPadded}
               isSortableColumn={sortable}
               sorted={isSorted(column)}
               onClick={event => onClick(event, column, sorting.onSortClick)}
@@ -268,7 +277,7 @@ const Thead = ({selectable}) => {
                 alignItems="center"
                 direction="row"
                 gap={0.5}
-                justifyContent={numeric && 'flex-end'}
+                justifyContent={(numeric || numericPadded) && 'flex-end'}
               >
                 <Box whiteSpace="normal">{heading}</Box>
                 <Stack alignItems="center" direction="row" gap={0.5}>
@@ -359,8 +368,11 @@ const TRow = ({item}) => {
           />
         </td>
       )}
-      {columns.map(({component, numeric}, cellIndex) => (
-        <td className={clsx(cell(), numeric && numericCell())} key={cellIndex}>
+      {columns.map(({component, numeric, numericPadded}, cellIndex) => (
+        <td
+          className={clsx(cell(), numeric && numericCell(), numericPadded && numericPaddedCell())}
+          key={cellIndex}
+        >
           {createElement(component, {item, linkRef: targetRef})}
         </td>
       ))}

--- a/packages/recipe/src/components/EzTable/EzTable.types.ts
+++ b/packages/recipe/src/components/EzTable/EzTable.types.ts
@@ -7,6 +7,7 @@ type Column = {
   icon?: ReactNode | ComponentType;
   key?: string;
   numeric?: boolean;
+  numericPadded?: boolean;
   sortable?: boolean;
   width?: number;
   /**


### PR DESCRIPTION
_Note: This PR is branched off `nb/eztable-stories` and should be merged after [PR #1057](https://github.com/ezcater/recipe/pull/1057)._

## What did we change?
- [feat: add numericPadded option to EzTable columns adding additional right padding](https://github.com/ezcater/recipe/commit/7d8faf8ea51173810a07f5b4a8336fea23a460d5) 

## Why are we doing this?
Request [[FEC-893](https://ezcater.atlassian.net/browse/FEC-893)].

## Screenshot(s) / Gif(s):
`numeric`:
<img width="623" alt="Screenshot 2023-10-03 at 10 42 36 AM" src="https://github.com/ezcater/recipe/assets/5418735/00b23606-a70a-4a2c-b974-ec63f96112b9">

`numericPadded`:
<img width="624" alt="Screenshot 2023-10-03 at 10 42 03 AM" src="https://github.com/ezcater/recipe/assets/5418735/23fde759-8dfc-4061-8f20-89b8760aa02e">

## Checklist

- [x] Provide test coverage for the changes made - regression test
- [x] Create a changeset (`yarn changeset`) with a summary of the changes
 

[FEC-893]: https://ezcater.atlassian.net/browse/FEC-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ