### PR TITLE
Add `topAlign` option to `EzTable` and `allowWrap` option to `EzTable` columns [FEC-907]

### DIFF
--- a/.changeset/dry-chicken-thank.md
+++ b/.changeset/dry-chicken-thank.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: add topAlign option to EzTable and allowWrap option to EzTable columns

--- a/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
+++ b/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
@@ -82,6 +82,7 @@ Use simple tables whenever the tabular data is directly related to the preceding
   - `numeric` (boolean): If true, the column is right aligned.
   - `numericPadded` (boolean): If true, the column is right aligned with a right padding of `32px`.
   - `width` (number): The width of the column.
+  - `allowWrap` (boolean): If true, the text in the column cells will wrap.
   - `component` (ReactNode | ComponentType): See [Interactive cells](#interactive-cells).
   - `sortable` (boolean): See [Sortable tables](#sortable).
   - `defaultSort` (`asc | desc`): See [Sortable tables](#sortable).
@@ -95,6 +96,12 @@ Use simple tables whenever the tabular data is directly related to the preceding
 Add the `fullWidth` property to allow a simple table to fill the parent element's width.
 
 <Canvas of={SimpleStories.SimpleFullWidth} meta={SimpleStories} />
+
+### `alignY`
+
+The `alignY` property will vertically align the table cells. Options are `center` (default), or `top`. Typically used if column cells have wrapping text (using the column `allowWrap` property).
+
+<Canvas of={SimpleStories.SimpleAlignY} meta={SimpleStories} />
 
 ## Composite
 

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Default.stories.tsx
@@ -20,6 +20,15 @@ const meta: Meta<typeof EzTable> = {
       description: 'The actions of the table. Must be used with table header.',
       table: {type: {summary: 'ReactNode'}},
     },
+    alignY: {
+      control: {type: 'select'},
+      description: 'The vertical alignment of the table.',
+      options: ['center', 'top'],
+      table: {
+        defaultValue: {summary: 'center'},
+        type: {summary: 'center | top'},
+      },
+    },
     ariaLabel: {
       control: {type: 'text'},
       description: 'The aria label of the table.',
@@ -33,6 +42,7 @@ const meta: Meta<typeof EzTable> = {
         type: {
           summary: `
             Column[
+              allowWrap?: boolean;
               component?: ReactNode | ComponentType;
               defaultSort?: 'asc' | 'desc';
               heading: string;
@@ -160,16 +170,14 @@ type Story = StoryObj<typeof EzTable>;
 
 const defaultArgs = {
   actions: <EzButton>Add store</EzButton>,
+  alignY: 'center',
   onSortClick: undefined,
   subtitle: 'Compared to the same period last year',
   title: 'All stores',
   titleIcon: <EzIcon icon={faCoffee} size="large" />,
-};
+} as EzTableProps;
 
-const defaultJSX = EzTableExampleJSX(
-  ['store', 'total', 'average', 'actions'],
-  defaultArgs as EzTableProps
-);
+const defaultJSX = EzTableExampleJSX(['store', 'total', 'average', 'actions'], defaultArgs);
 
 export const Default: Story = {
   args: defaultArgs,

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Regression.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Regression.stories.tsx
@@ -235,3 +235,41 @@ export const NumericPadded: Story = {
     />
   ),
 };
+
+export const TopAligned: Story = {
+  render: () => (
+    <EzTable
+      alignY="top"
+      columns={[
+        {heading: 'Store name', key: 'store', width: 200},
+        {heading: 'Description', key: 'description', allowWrap: true},
+      ]}
+      items={[
+        {
+          id: '#001',
+          store: 'Ten Forward',
+          description:
+            'Serves as the social center of the Enterprise and is equipped with a number of recreational activities such as three-dimensional chess, Terrace, and Strategema, tables and seating, and a bar which serves several alcoholic and syntheholic beverages. Designed with several large windows, which offers a spectacular view of space ahead of the vessel.',
+        },
+        {
+          id: '#002',
+          store: "Sisko's Kitchen",
+          description:
+            'A restaurant in the French Quarter of New Orleans serving blackened redfish, shrimp creole, shrimp remoulade, crawfish étouffée, jambalaya, pasta boudin, and gumbo.',
+        },
+        {
+          id: '#003',
+          store: "Quark's Bar",
+          description: 'A popular recreational facility located on the space station Deep Space 9.',
+        },
+        {
+          id: '#004',
+          store: 'Betazoid Bakery',
+          description:
+            'Produces and sells flour-based food baked in an oven such as bread, cookies, cakes, doughnuts, bagels, pastries, and pies.',
+        },
+      ]}
+      title="Store descriptions"
+    />
+  ),
+};

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Simple.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Simple.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {type Meta, type StoryObj} from '@storybook/react';
+import dedent from 'ts-dedent';
 import EzTable from '../../EzTable';
 import DefaultMeta from './Default.stories';
 import {EzTableExample, EzTableExampleJSX} from '../EzTableExample';
@@ -39,4 +40,83 @@ export const SimpleFullWidth: Story = {
     playroom: {code: simpleFullWidthJSX},
   },
   render: args => <EzCard>{EzTableExample(['store', 'total', 'average'], args)}</EzCard>,
+};
+
+const simpleAlignYJSX = dedent`
+  <EzTable
+    alignY="top"
+    columns={[
+      {heading: 'Store name', key: 'store', width: 200},
+      {heading: 'Description', key: 'description', allowWrap: true},
+    ]}
+    items={[
+      {
+        id: '#001',
+        store: 'Ten Forward',
+        description:
+          'Serves as the social center of the Enterprise and is equipped with a number of recreational activities such as three-dimensional chess, Terrace, and Strategema, tables and seating, and a bar which serves several alcoholic and syntheholic beverages. Designed with several large windows, which offers a spectacular view of space ahead of the vessel.',
+      },
+      {
+        id: '#002',
+        store: "Sisko's Kitchen",
+        description:
+          'A restaurant in the French Quarter of New Orleans serving blackened redfish, shrimp creole, shrimp remoulade, crawfish étouffée, jambalaya, pasta boudin, and gumbo.',
+      },
+      {
+        id: '#003',
+        store: "Quark's Bar",
+        description: 'A popular recreational facility located on the space station Deep Space 9.',
+      },
+      {
+        id: '#004',
+        store: 'Betazoid Bakery',
+        description:
+          'Produces and sells flour-based food baked in an oven such as bread, cookies, cakes, doughnuts, bagels, pastries, and pies.',
+      },
+    ]}
+  />
+`;
+
+export const SimpleAlignY: Story = {
+  args: {
+    alignY: 'top',
+  },
+  parameters: {
+    docs: {source: {code: simpleAlignYJSX}},
+    playroom: {code: simpleAlignYJSX},
+  },
+  render: args => (
+    <EzTable
+      columns={[
+        {heading: 'Store name', key: 'store', width: 200},
+        {heading: 'Description', key: 'description', allowWrap: true},
+      ]}
+      items={[
+        {
+          id: '#001',
+          store: 'Ten Forward',
+          description:
+            'Serves as the social center of the Enterprise and is equipped with a number of recreational activities such as three-dimensional chess, Terrace, and Strategema, tables and seating, and a bar which serves several alcoholic and syntheholic beverages. Designed with several large windows, which offers a spectacular view of space ahead of the vessel.',
+        },
+        {
+          id: '#002',
+          store: "Sisko's Kitchen",
+          description:
+            'A restaurant in the French Quarter of New Orleans serving blackened redfish, shrimp creole, shrimp remoulade, crawfish étouffée, jambalaya, pasta boudin, and gumbo.',
+        },
+        {
+          id: '#003',
+          store: "Quark's Bar",
+          description: 'A popular recreational facility located on the space station Deep Space 9.',
+        },
+        {
+          id: '#004',
+          store: 'Betazoid Bakery',
+          description:
+            'Produces and sells flour-based food baked in an oven such as bread, cookies, cakes, doughnuts, bagels, pastries, and pies.',
+        },
+      ]}
+      {...args}
+    />
+  ),
 };

--- a/packages/recipe/src/components/EzTable/EzTable.tsx
+++ b/packages/recipe/src/components/EzTable/EzTable.tsx
@@ -68,6 +68,10 @@ const numericPaddedCell = theme.css({
   paddingRight: '32px',
 });
 
+const noWrap = theme.css({
+  whiteSpace: 'nowrap',
+});
+
 const header = theme.css({
   fontWeight: '$table-heading',
   fontSize: '$table-heading',
@@ -103,6 +107,10 @@ const fullWidthTable = theme.css({
   width: '100%',
 });
 
+const alignTop = theme.css({
+  verticalAlign: 'top',
+});
+
 const transparentBackground = theme.css({
   backgroundColor: 'inherit',
 });
@@ -117,7 +125,6 @@ const base = theme.css({
   lineHeight: '$table',
   color: '$table-text',
   backgroundColor: 'white',
-  whiteSpace: 'nowrap',
 
   variants: {
     use: {
@@ -201,12 +208,12 @@ const SortIcon = ({direction, isSorted}) => (
 
 type ThProps = {
   children: any;
-  numeric?: boolean;
-  numericPadded?: boolean;
   isSelection?: boolean;
   isSortableColumn?: boolean;
-  sorted?: boolean;
+  numeric?: boolean;
+  numericPadded?: boolean;
   onClick?: any;
+  sorted?: boolean;
   width?: number;
 };
 
@@ -368,9 +375,14 @@ const TRow = ({item}) => {
           />
         </td>
       )}
-      {columns.map(({component, numeric, numericPadded}, cellIndex) => (
+      {columns.map(({allowWrap, component, numeric, numericPadded}, cellIndex) => (
         <td
-          className={clsx(cell(), numeric && numericCell(), numericPadded && numericPaddedCell())}
+          className={clsx(
+            cell(),
+            !allowWrap && noWrap(),
+            numeric && numericCell(),
+            numericPadded && numericPaddedCell()
+          )}
           key={cellIndex}
         >
           {createElement(component, {item, linkRef: targetRef})}
@@ -381,9 +393,9 @@ const TRow = ({item}) => {
 };
 
 const Tbody = () => {
-  const {items} = useContext(TableContext);
+  const {alignY, items} = useContext(TableContext);
   return (
-    <tbody>
+    <tbody className={clsx(alignY === 'top' && alignTop())}>
       {items.map((item, rowIndex) => (
         <TRow key={item.key || rowIndex} item={item} />
       ))}
@@ -394,10 +406,6 @@ const Tbody = () => {
 const iconSize = theme.css({
   height: 24,
   width: 24,
-});
-
-const rangeWrapper = theme.css({
-  whiteSpace: 'nowrap',
 });
 
 const paginationNav = theme.css({
@@ -486,7 +494,7 @@ const TablePagination = ({pagination}) => {
     <EzFooter>
       <EzLayout layout="right">
         <nav aria-label={t('Pagination')} className={paginationNav()}>
-          <span className={rangeWrapper()}>{t('{{range}} of {{count}}', {range, count})}</span>
+          <span className={noWrap()}>{t('{{range}} of {{count}}', {range, count})}</span>
 
           <div className={virtualTouchable()}>
             <EzIconButton
@@ -546,17 +554,18 @@ const TablePagination = ({pagination}) => {
  */
 const EzTable: FC<EzTableProps> = ({
   actions,
-  title,
-  subtitle,
+  alignY = 'center',
+  ariaLabel,
   columns,
+  fullWidth,
   items,
-  selection,
   onSortClick,
   pagination,
+  selection,
   showCardWithoutHeading,
-  ariaLabel,
+  subtitle,
+  title,
   titleIcon,
-  fullWidth,
   transparent,
 }) => {
   const rowsSelectedOnCurrentPage = selection && items.filter(selection.isRowSelected);
@@ -583,6 +592,7 @@ const EzTable: FC<EzTableProps> = ({
   const table = (
     <TableContext.Provider
       value={{
+        alignY,
         items,
         selection: selection && {
           ...selection,
@@ -629,5 +639,7 @@ const EzTable: FC<EzTableProps> = ({
     </EzCard>
   );
 };
+
+EzTable.displayName = 'EzTable';
 
 export default EzTable;

--- a/packages/recipe/src/components/EzTable/EzTable.types.ts
+++ b/packages/recipe/src/components/EzTable/EzTable.types.ts
@@ -1,6 +1,7 @@
 import type {ComponentType, MouseEvent, MouseEventHandler, ReactNode} from 'react';
 
 type Column = {
+  allowWrap?: boolean;
   component?: ReactNode | ComponentType;
   defaultSort?: Direction;
   heading: string;
@@ -97,12 +98,13 @@ type PaginationSelectionCombination =
   | PaginationAndSelectionDisabled;
 
 type TableBase = {
-  subtitle?: string;
+  alignY?: 'center' | 'top';
   columns: Column[];
+  fullWidth?: boolean;
   items: any[];
   onSortClick?: onSortClick;
+  subtitle?: string;
   titleIcon?: ReactNode;
-  fullWidth?: boolean;
   transparent?: boolean;
 };
 


### PR DESCRIPTION
_Note: This PR is branched off `nb/eztable-numeric-padding` and should be merged after https://github.com/ezcater/recipe/pull/1058._

## What did we change?
- [feat: add topAlign option to EzTable and allowWrap option to EzTable columns](https://github.com/ezcater/recipe/commit/b65ab23e27a65c9c6cfefbf4a898a7baa6f632ab) 

## Why are we doing this?
Request [[FEC-907](https://ezcater.atlassian.net/browse/FEC-907)].

## Screenshot(s) / Gif(s):
<img width="873" alt="Screenshot 2023-10-04 at 2 24 29 PM" src="https://github.com/ezcater/recipe/assets/5418735/75386ba4-2567-481f-bfaa-39a7f12f1540">

## Checklist
- [x] Provide test coverage for the changes made
- [x] Create a changeset (`yarn changeset`) with a summary of the changes

[FEC-907]: https://ezcater.atlassian.net/browse/FEC-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ