### PR TITLE
fix: remove data-testid from EzCard

### DIFF
--- a/.changeset/famous-news-do.md
+++ b/.changeset/famous-news-do.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+fix: remove data-testid from EzCard

--- a/packages/recipe/src/components/EzCard/Documentation/Stories/Action.stories.tsx
+++ b/packages/recipe/src/components/EzCard/Documentation/Stories/Action.stories.tsx
@@ -61,7 +61,6 @@ export const MultipleActions: Story = {
               <EzButton>View</EzButton>
             </EzLayout>
           }
-          data-testid="ez-card"
           subtitle="Upscale Authentic Flavor | 6 mi | $$$$"
           title="Amuleto Mexican Table"
         >
@@ -79,7 +78,6 @@ export const MultipleActions: Story = {
             <EzButton>View</EzButton>
           </EzLayout>
         }
-        data-testid="ez-card"
         subtitle="Upscale Authentic Flavor | 6 mi | $$$$"
         title="Amuleto Mexican Table"
       >
@@ -101,7 +99,6 @@ export const Clickable: Story = {
       code: dedent`
         <EzCard
           clickable
-          data-testid="ez-card"
           onClick={() => {}}
           subtitle="Upscale Authentic Flavor | 6 mi | $$$$"
           title="Amuleto Mexican Table"
@@ -113,7 +110,7 @@ export const Clickable: Story = {
   },
   play: ({args, canvasElement}) => {
     const canvas = within(canvasElement);
-    userEvent.click(canvas.getAllByTestId('ez-card')[0]);
+    userEvent.click(canvas.getAllByText('Amuleto Mexican Table')[0]);
     expect(args.onClick).toHaveBeenCalled();
   },
   render: (args: EzCardProps) => EzCardSimpleExample(args),
@@ -123,7 +120,6 @@ delete Clickable.args.onClick;
 const ClickableHeaderLinkCard = (args?: EzCardProps, includeCTA?: boolean) => (
   <EzCard
     {...args}
-    data-testid="ez-card"
     imageSrc="/images/tacos.jpg"
     imagePosition="left"
     imageMaxWidth={200}
@@ -168,7 +164,6 @@ const ClickableHeaderLinkCard = (args?: EzCardProps, includeCTA?: boolean) => (
 const ClickableHeaderLinkCardJSX = (includeCTA?: boolean) => dedent`
   <EzCard
     clickable
-    data-testid="ez-card"
     imageSrc="/images/tacos.jpg"
     imagePosition="left"
     imageMaxWidth={200}

--- a/packages/recipe/src/components/EzCard/Documentation/Stories/Action.stories.tsx
+++ b/packages/recipe/src/components/EzCard/Documentation/Stories/Action.stories.tsx
@@ -61,6 +61,7 @@ export const MultipleActions: Story = {
               <EzButton>View</EzButton>
             </EzLayout>
           }
+          data-testid="ez-card"
           subtitle="Upscale Authentic Flavor | 6 mi | $$$$"
           title="Amuleto Mexican Table"
         >
@@ -78,6 +79,7 @@ export const MultipleActions: Story = {
             <EzButton>View</EzButton>
           </EzLayout>
         }
+        data-testid="ez-card"
         subtitle="Upscale Authentic Flavor | 6 mi | $$$$"
         title="Amuleto Mexican Table"
       >
@@ -99,6 +101,7 @@ export const Clickable: Story = {
       code: dedent`
         <EzCard
           clickable
+          data-testid="ez-card"
           onClick={() => {}}
           subtitle="Upscale Authentic Flavor | 6 mi | $$$$"
           title="Amuleto Mexican Table"
@@ -120,6 +123,7 @@ delete Clickable.args.onClick;
 const ClickableHeaderLinkCard = (args?: EzCardProps, includeCTA?: boolean) => (
   <EzCard
     {...args}
+    data-testid="ez-card"
     imageSrc="/images/tacos.jpg"
     imagePosition="left"
     imageMaxWidth={200}
@@ -164,6 +168,7 @@ const ClickableHeaderLinkCard = (args?: EzCardProps, includeCTA?: boolean) => (
 const ClickableHeaderLinkCardJSX = (includeCTA?: boolean) => dedent`
   <EzCard
     clickable
+    data-testid="ez-card"
     imageSrc="/images/tacos.jpg"
     imagePosition="left"
     imageMaxWidth={200}

--- a/packages/recipe/src/components/EzCard/EzCard.tsx
+++ b/packages/recipe/src/components/EzCard/EzCard.tsx
@@ -95,7 +95,6 @@ const EzCard: React.FC<DOMProps & EzCardProps> = ({
         }),
         transparent && transparentBackground()
       )}
-      data-testid="ez-card"
       style={{...style, '--sizes-card-preview-max-w': unitlessToPx(maxWidth)} as any}
     >
       <SlotProvider


### PR DESCRIPTION
## What did we change?
- Remove hard-coded `data-testid` from `EzCard` to allow downstream apps to pass a data test id

## Why are we doing this?
- Blocking 18.3.0 upgrade for downstream apps

## Screenshot(s) / Gif(s):
<img width="1151" alt="Screenshot 2023-10-06 at 12 10 06 PM" src="https://github.com/ezcater/recipe/assets/3790037/497e71ee-32e1-4078-bde9-c2d65bc754b8">

## Checklist

- [x] Provide test coverage for the changes made
- [x] Create a changeset (`yarn changeset`) with a summary of the changes
 
[Contributing guidelines](https://recipe.ezcater.com/?path=/docs/guides-contributing--docs)