### PR TITLE
Add `blankState` option to `EzTable` [FEC-725]

### DIFF
--- a/.changeset/fifty-glasses-punch.md
+++ b/.changeset/fifty-glasses-punch.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': minor
+---
+
+feat: add blankState option to EzTable

--- a/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
+++ b/packages/recipe/src/components/EzTable/Documentation/EzTable.mdx
@@ -83,6 +83,7 @@ Use simple tables whenever the tabular data is directly related to the preceding
   - `numericPadded` (boolean): If true, the column is right aligned with a right padding of `32px`.
   - `width` (number): The width of the column.
   - `allowWrap` (boolean): If true, the text in the column cells will wrap.
+  - `blankState` (ReactNode): Pass in an optional `EzBlankState` to the table that will display if no items are passed to the table. See [Blank state](#blankstate).
   - `component` (ReactNode | ComponentType): See [Interactive cells](#interactive-cells).
   - `sortable` (boolean): See [Sortable tables](#sortable).
   - `defaultSort` (`asc | desc`): See [Sortable tables](#sortable).
@@ -126,6 +127,17 @@ To maintain accessibility, provide an `ariaLabel` and optionally a heading or la
 Add the `transparent` property to inherit the parent element's background color.
 
 <Canvas of={CompositeStories.CompositeTransparent} meta={CompositeStories} />
+
+### `blankState`
+
+To render a blank state when the table does not have any data, pass in `blankState` to `EzTable` with the [EzBlankState](?path=/docs/layout-ezblankstate--docs) you'd like to display.
+
+Include the following `EzBlankState` properties:
+
+- `title` (string): `You don't have any [table name] yet`
+- `message` (string): `[Value proposition sentence.] As you create [table name], they'll appear here.`
+
+<Canvas of={CompositeStories.CompositeBlankState} meta={CompositeStories} />
 
 ## Interactive
 
@@ -241,4 +253,4 @@ Multiple filters can be used across pages to filter a data set in a table. To av
 
 ## Related components
 
-<RelatedComponents components={['EzCard']} />
+<RelatedComponents components={['EzBlankState', 'EzCard']} />

--- a/packages/recipe/src/components/EzTable/Documentation/Stories/Composite.stories.tsx
+++ b/packages/recipe/src/components/EzTable/Documentation/Stories/Composite.stories.tsx
@@ -11,6 +11,7 @@ import EzIcon from '../../../EzIcon';
 import EzLayout from '../../../EzLayout';
 import EzSearchInput from '../../../EzSearchInput';
 import EzTable from '../../EzTable';
+import EzBlankState from '../../../EzBlankState';
 
 const meta: Meta<typeof EzTable> = {
   argTypes: DefaultMeta.argTypes,
@@ -77,6 +78,37 @@ export const CompositeTransparent: Story = {
   parameters: {
     docs: {source: {code: compositeTransparentJSX}},
     playroom: {code: compositeTransparentJSX},
+  },
+  render: args => (
+    <EzCard style={{backgroundColor: color.lighter}}>{EzTableExample(compositeKeys, args)}</EzCard>
+  ),
+};
+
+const compositeBlankStateArgs = {
+  actions: <EzButton>Create custom checkout field</EzButton>,
+  blankState: (
+    <EzBlankState
+      message="Adding a custom checkout field can help you organize food spend, customize reports, split and manage invoicing, and/or ensure compliance. As you create custom checkout fields, they'll appear here."
+      title="You don't have any custom checkout fields yet"
+    />
+  ),
+  columns: [
+    {heading: 'Field', key: 'field'},
+    {heading: 'Field details', key: 'details'},
+  ],
+  items: [],
+  title: 'Custom checkout fields',
+};
+const compositeBlankStateJSX = EzTableExampleJSX(
+  compositeKeys,
+  compositeBlankStateArgs as EzTableProps
+);
+
+export const CompositeBlankState: Story = {
+  args: compositeBlankStateArgs as EzTableProps,
+  parameters: {
+    docs: {source: {code: compositeBlankStateJSX}},
+    playroom: {code: compositeBlankStateJSX},
   },
   render: args => (
     <EzCard style={{backgroundColor: color.lighter}}>{EzTableExample(compositeKeys, args)}</EzCard>

--- a/packages/recipe/src/components/EzTable/EzTable.tsx
+++ b/packages/recipe/src/components/EzTable/EzTable.tsx
@@ -72,6 +72,10 @@ const noWrap = theme.css({
   whiteSpace: 'nowrap',
 });
 
+const noWrap = theme.css({
+  whiteSpace: 'nowrap',
+});
+
 const header = theme.css({
   fontWeight: '$table-heading',
   fontSize: '$table-heading',

--- a/packages/recipe/src/components/EzTable/EzTable.tsx
+++ b/packages/recipe/src/components/EzTable/EzTable.tsx
@@ -72,10 +72,6 @@ const noWrap = theme.css({
   whiteSpace: 'nowrap',
 });
 
-const noWrap = theme.css({
-  whiteSpace: 'nowrap',
-});
-
 const header = theme.css({
   fontWeight: '$table-heading',
   fontSize: '$table-heading',
@@ -560,6 +556,7 @@ const EzTable: FC<EzTableProps> = ({
   actions,
   alignY = 'center',
   ariaLabel,
+  blankState,
   columns,
   fullWidth,
   items,
@@ -637,7 +634,7 @@ const EzTable: FC<EzTableProps> = ({
         {actions && showCardWithoutHeading && (
           <div className={cardWithoutHeaderActions()}>{actions}</div>
         )}
-        {table}
+        {blankState && items.length === 0 ? blankState : table}
       </TableCardSection>
       {pagination && <TablePagination pagination={pagination} />}
     </EzCard>

--- a/packages/recipe/src/components/EzTable/EzTable.types.ts
+++ b/packages/recipe/src/components/EzTable/EzTable.types.ts
@@ -99,6 +99,7 @@ type PaginationSelectionCombination =
 
 type TableBase = {
   alignY?: 'center' | 'top';
+  blankState?: ReactNode;
   columns: Column[];
   fullWidth?: boolean;
   items: any[];


### PR DESCRIPTION
_Note: This PR is branched off `nb/eztable-vertical-align` and should be merged after https://github.com/ezcater/recipe/pull/1059._

## What did we change?
- [feat: add blankState option to EzTable](https://github.com/ezcater/recipe/commit/aacbdd8e250ec815f7194be45336ca00484fb1bc)

## Why are we doing this?
Request [[FEC-709](https://ezcater.atlassian.net/browse/FEC-709)].
[Design](https://www.figma.com/file/3T0PuTpgMT2pE5HnbLE4Xp/Corporate-Dashboard?type=design&node-id=4719%3A12076&mode=design&t=MaQupyO9ReHo8b5s-1).

## Screenshot(s) / Gif(s):
<img width="1028" alt="Screenshot 2023-10-10 at 9 17 08 AM" src="https://github.com/ezcater/recipe/assets/5418735/bb62378d-eae3-4fdb-8600-eb5558dbe717">
<img width="1703" alt="Screenshot 2023-10-10 at 9 17 56 AM" src="https://github.com/ezcater/recipe/assets/5418735/54922d69-079c-4292-8f58-6e24ad7226bd">

## Checklist
- [x] Provide test coverage for the changes made
- [x] Create a changeset (`yarn changeset`) with a summary of the changes

[FEC-709]: https://ezcater.atlassian.net/browse/FEC-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ