### PR TITLE
Added radius design tokens to themes [FEC-953]

### DIFF
--- a/.changeset/few-gifts-rescue.md
+++ b/.changeset/few-gifts-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+style: add radius design tokens to themes

--- a/packages/recipe/docs/components/DesignTokens/DesignTokens.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokens.tsx
@@ -12,7 +12,7 @@ type TokenType = {
 // TODO: add remaining tokens
 const TOKEN_TYPES: Array<TokenType> = [
   {type: 'color', group: true},
-  // {type: 'radius', group: false},
+  {type: 'radius', group: false},
   {type: 'shadow', group: false},
   // {type: 'spacing', group: false},
   // {type: 'typography', group: false},

--- a/packages/recipe/docs/components/DesignTokens/DesignTokensDisplay.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokensDisplay.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
 } from '@mui/material';
 import {color as storybookColor} from '@storybook/theming';
-import {color, shadow} from '../../../src/themes/tokens';
+import {color, radius, shadow} from '../../../src/themes/tokens';
 import {DesignTokensDisplayProps} from './DesignTokens.types';
 import {EzThemeTokens} from '../../../src/themes/themes.types';
 import CopyButton from './CopyButton';
@@ -44,16 +44,24 @@ const CodeBlock = ({children, withCopy = false}) => {
 };
 
 const DesignTokenPreview = ({token, tokenType}) => {
+  const theme = useTheme();
+
   // TODO: add remaining tokens
   const previewMap = {
     color: {
       displayText: color[token[0]]?.displayText,
-      style: 'bgcolor',
+      sx: {bgcolor: color[token[0]]?.value},
     },
-    // radius: {style: 'borderRadius'},
+    radius: {
+      displayText: radius[token[0]]?.displayText,
+      sx: {
+        backgroundColor: theme.tokens['color-surface-neutral-default'],
+        borderRadius: radius[token[0]]?.value,
+      },
+    },
     shadow: {
       displayText: shadow[token[0]]?.displayText,
-      style: 'boxShadow',
+      sx: {boxShadow: shadow[token[0]]?.value},
     },
     // spacing: {style: 'padding'},
     // typography: {style: 'fontFamily'},
@@ -61,12 +69,7 @@ const DesignTokenPreview = ({token, tokenType}) => {
 
   return (
     <Stack alignItems="center" direction="row" gap={3}>
-      <Box
-        borderRadius="4px"
-        height="40px"
-        minWidth="40px"
-        sx={{[previewMap[tokenType].style]: token[1]}}
-      />
+      <Box borderRadius="4px" height="40px" minWidth="40px" sx={previewMap[tokenType].sx} />
       <Box>{previewMap[tokenType].displayText}</Box>
     </Stack>
   );

--- a/packages/recipe/src/themes/mui/ezTheme.ts
+++ b/packages/recipe/src/themes/mui/ezTheme.ts
@@ -1,7 +1,7 @@
 import {createTheme, responsiveFontSizes} from '@mui/material';
 import {ezPalette, legacyColors} from '../ezColors';
 import type {EzPaletteOptions, EzThemeTokens} from '../themes.types';
-import {color, shadow} from '../tokens';
+import {color, radius, shadow} from '../tokens';
 
 declare module '@mui/material/styles/createTheme' {
   interface Theme {
@@ -380,6 +380,7 @@ const ezTheme = responsiveFontSizes(
     palette,
     tokens: {
       ...getTokens(color),
+      ...getTokens(radius),
       ...getTokens(shadow),
     },
     typography,

--- a/packages/recipe/src/themes/tokens/index.ts
+++ b/packages/recipe/src/themes/tokens/index.ts
@@ -1,2 +1,3 @@
 export {color} from './color';
+export {radius} from './radius';
 export {shadow} from './shadow';

--- a/packages/recipe/src/themes/tokens/radius.ts
+++ b/packages/recipe/src/themes/tokens/radius.ts
@@ -1,0 +1,14 @@
+export const radius = {
+  'radius-default': {
+    displayText: 'Uses a radius of 8 pixels.',
+    value: '8px',
+  },
+  'radius-sm': {
+    displayText: 'Uses a radius of 4 pixels.',
+    value: '4px',
+  },
+  'radius-full': {
+    displayText: 'Uses a full radius for full rounded corners.',
+    value: '999px',
+  },
+};


### PR DESCRIPTION
## What did we change?
- [style: add radius design tokens to themes](https://github.com/ezcater/recipe/commit/bc06ed1b167dbc49f9308dc9061397b1440c4c27)

## Why are we doing this?
Adds border radius design tokens in Recipe themes including documentation. This does not update any of our components to use these new design tokens. That will be done in a separate PR.

## Screenshot(s) / Gif(s):
<img width="1704" alt="Screenshot 2023-10-16 at 4 56 41 PM" src="https://github.com/ezcater/recipe/assets/5418735/e7b571e8-f1dc-4c7c-a83f-8a9104ff9843">

## Checklist

- [x] Create a changeset (`yarn changeset`) with a summary of the changes