### PR TITLE
Added spacing design tokens to themes [FEC-954]

### DIFF
--- a/.changeset/angry-rings-prove.md
+++ b/.changeset/angry-rings-prove.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+style: add spacing design tokens to themes

--- a/packages/recipe/docs/components/DesignTokens/DesignTokens.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokens.tsx
@@ -14,7 +14,7 @@ const TOKEN_TYPES: Array<TokenType> = [
   {type: 'color', group: true},
   {type: 'radius', group: false},
   {type: 'shadow', group: false},
-  // {type: 'spacing', group: false},
+  {type: 'spacing', group: false},
   // {type: 'typography', group: false},
 ];
 

--- a/packages/recipe/docs/components/DesignTokens/DesignTokensDisplay.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokensDisplay.tsx
@@ -10,9 +10,8 @@ import {
   useTheme,
 } from '@mui/material';
 import {color as storybookColor} from '@storybook/theming';
-import {color, radius, shadow} from '../../../src/themes/tokens';
+import {color, radius, shadow, spacing} from '../../../src/themes/tokens';
 import {DesignTokensDisplayProps} from './DesignTokens.types';
-import {EzThemeTokens} from '../../../src/themes/themes.types';
 import CopyButton from './CopyButton';
 
 const CodeBlock = ({children, withCopy = false}) => {
@@ -63,7 +62,14 @@ const DesignTokenPreview = ({token, tokenType}) => {
       displayText: shadow[token[0]]?.displayText,
       sx: {boxShadow: shadow[token[0]]?.value},
     },
-    // spacing: {style: 'padding'},
+    spacing: {
+      displayText: spacing[token[0]]?.displayText,
+      sx: {
+        backgroundColor: theme.tokens['color-surface-neutral-default'],
+        borderRadius: theme.tokens['radius-none'],
+        minWidth: spacing[token[0]]?.value,
+      },
+    },
     // typography: {style: 'fontFamily'},
   };
 

--- a/packages/recipe/src/themes/mui/ezTheme.ts
+++ b/packages/recipe/src/themes/mui/ezTheme.ts
@@ -1,7 +1,7 @@
 import {createTheme, responsiveFontSizes} from '@mui/material';
 import {ezPalette, legacyColors} from '../ezColors';
 import type {EzPaletteOptions, EzThemeTokens} from '../themes.types';
-import {color, radius, shadow} from '../tokens';
+import {color, radius, shadow, spacing} from '../tokens';
 
 declare module '@mui/material/styles/createTheme' {
   interface Theme {
@@ -382,6 +382,7 @@ const ezTheme = responsiveFontSizes(
       ...getTokens(color),
       ...getTokens(radius),
       ...getTokens(shadow),
+      ...getTokens(spacing),
     },
     typography,
   })

--- a/packages/recipe/src/themes/tokens/index.ts
+++ b/packages/recipe/src/themes/tokens/index.ts
@@ -1,3 +1,4 @@
 export {color} from './color';
 export {radius} from './radius';
 export {shadow} from './shadow';
+export {spacing} from './spacing';

--- a/packages/recipe/src/themes/tokens/spacing.ts
+++ b/packages/recipe/src/themes/tokens/spacing.ts
@@ -1,0 +1,20 @@
+const MULTIPLIER = 4; // 1 spacing unit = 4px
+
+export const spacing = {
+  'spacing-0': {value: `${MULTIPLIER * 0}px`},
+  'spacing-05': {value: `${MULTIPLIER * 0.5}px`},
+  'spacing-1': {value: `${MULTIPLIER * 1}px`},
+  'spacing-2': {value: `${MULTIPLIER * 2}px`},
+  'spacing-3': {value: `${MULTIPLIER * 3}px`},
+  'spacing-4': {value: `${MULTIPLIER * 4}px`},
+  'spacing-5': {value: `${MULTIPLIER * 5}px`},
+  'spacing-6': {value: `${MULTIPLIER * 6}px`},
+  'spacing-7': {value: `${MULTIPLIER * 7}px`},
+  'spacing-8': {value: `${MULTIPLIER * 8}px`},
+  'spacing-12': {value: `${MULTIPLIER * 12}px`},
+  'spacing-16': {value: `${MULTIPLIER * 16}px`},
+  'spacing-20': {value: `${MULTIPLIER * 20}px`},
+  'spacing-24': {value: `${MULTIPLIER * 24}px`},
+  'spacing-28': {value: `${MULTIPLIER * 28}px`},
+  'spacing-32': {value: `${MULTIPLIER * 32}px`},
+};


### PR DESCRIPTION
## What did we change?
- [style: add spacing design tokens to themes](https://github.com/ezcater/recipe/commit/2981e1369e24d448478ce452be3542dcb271594e)

## Why are we doing this?
Added spacing design tokens in Recipe themes including documentation. This does not update any of our components to use these new design tokens. That will be done in a separate PR.

## Screenshot(s) / Gif(s):
<img width="1705" alt="Screenshot 2023-10-17 at 9 10 39 AM" src="https://github.com/ezcater/recipe/assets/5418735/11160326-9289-4107-a833-480e975d7788">

## Checklist
- [x] Create a changeset (`yarn changeset`) with a summary of the changes