### PR TITLE
Added typography design tokens to themes and updated fonts

### DIFF
--- a/.changeset/big-sloths-fetch.md
+++ b/.changeset/big-sloths-fetch.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+style: add typography design tokens to themes

--- a/.changeset/seven-days-sing.md
+++ b/.changeset/seven-days-sing.md
@@ -1,0 +1,5 @@
+---
+'@ezcater/recipe': patch
+---
+
+style: update fonts to add new lato (includes semibold) and roboto

--- a/packages/recipe/.storybook/preview-head.html
+++ b/packages/recipe/.storybook/preview-head.html
@@ -1,17 +1,22 @@
+<!-- Montserrat and Roboto Flex (deprecated) from Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <!-- preload custom fonts: https://www.chromatic.com/docs/resource-loading#loading-custom-fonts -->
 <link
+  href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
   rel="preload"
   as="style"
-  href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
   crossorigin
 />
 <link
+  href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
   rel="stylesheet"
-  href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
   crossorigin
 />
+<!-- Lato and Roboto from Adobe Fonts -->
+<!-- preload custom fonts: https://www.chromatic.com/docs/resource-loading#loading-custom-fonts -->
+<link as="style" href="https://use.typekit.net/dnm5yzr.css" rel="preload" crossorigin />
+<link href="https://use.typekit.net/dnm5yzr.css" rel="stylesheet" crossorigin />
 
 <style>
   .sbdocs.sbdocs-content * {

--- a/packages/recipe/docs/components/DesignTokens/CodeBlock.tsx
+++ b/packages/recipe/docs/components/DesignTokens/CodeBlock.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {Box, useTheme} from '@mui/material';
+import {CodeBlockProps} from './DesignTokens.types';
+import CopyButton from './CopyButton';
+
+const CodeBlock = ({children, withCopy = false}: CodeBlockProps) => {
+  const theme = useTheme();
+
+  return (
+    <Box position="relative">
+      <Box
+        bgcolor={theme.tokens['color-surface-neutral-bold']}
+        borderRadius="4px"
+        overflow="auto"
+        pl={2}
+        pr={withCopy ? 4 : 2}
+      >
+        <Box aria-hidden={true} color={theme.tokens['color-text-contrast']} component="pre" my={1}>
+          <Box component="code" whiteSpace="pre-wrap">
+            {children}
+          </Box>
+        </Box>
+      </Box>
+
+      {withCopy && (
+        <Box position="absolute" top="4px" right="4px">
+          <CopyButton darkMode textToCopy={children} />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default CodeBlock;

--- a/packages/recipe/docs/components/DesignTokens/CopyButton.tsx
+++ b/packages/recipe/docs/components/DesignTokens/CopyButton.tsx
@@ -1,12 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import {IconButton} from '@mui/material';
-import EzIcon from '../../../src/components/EzIcon';
+import {CopyButtonProps} from './DesignTokens.types';
 import {faCircleCheck, faCopy} from '@fortawesome/free-solid-svg-icons';
-
-interface CopyButtonProps {
-  darkMode?: boolean;
-  textToCopy: string;
-}
+import EzIcon from '../../../src/components/EzIcon';
 
 const CopyButton = ({textToCopy, darkMode = false}: CopyButtonProps) => {
   const [showCopied, setShowCopied] = useState(false);

--- a/packages/recipe/docs/components/DesignTokens/DesignTokenPreview.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokenPreview.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {Box, Stack, useTheme} from '@mui/material';
+import {color, radius, shadow, spacing, typography} from '../../../src/themes/tokens';
+import {DesignTokenPreviewProps} from './DesignTokens.types';
+
+const DesignTokenPreview = ({token, tokenType}: DesignTokenPreviewProps) => {
+  const theme = useTheme();
+  const tokenGroup = token[0].split('-')[1];
+
+  const previewMap = {
+    color: {
+      displayText: color[token[0]]?.displayText,
+      sx: {bgcolor: color[token[0]]?.value},
+    },
+    radius: {
+      displayText: radius[token[0]]?.displayText,
+      sx: {
+        backgroundColor: theme.tokens['color-surface-neutral-default'],
+        borderRadius: radius[token[0]]?.value,
+      },
+    },
+    shadow: {
+      displayText: shadow[token[0]]?.displayText,
+      sx: {boxShadow: shadow[token[0]]?.value},
+    },
+    spacing: {
+      displayText: spacing[token[0]]?.displayText,
+      sx: {
+        backgroundColor: theme.tokens['color-surface-neutral-default'],
+        borderRadius: theme.tokens['radius-none'],
+        minWidth: spacing[token[0]]?.value,
+      },
+    },
+    typography: {
+      displayText: typography[token[0]]?.displayText,
+      sx: {
+        display: '-webkit-box',
+        fontFamily:
+          tokenGroup === 'fontfamily' ? typography[token[0]].value : theme.typography.fontFamily,
+        fontSize:
+          tokenGroup === 'fontsize'
+            ? typography[token[0]]?.value
+            : theme.tokens['typography-fontsize-100'],
+        fontStyle:
+          tokenGroup === 'fontstyle'
+            ? typography[token[0]].value
+            : theme.tokens['typography-fontstyle-normal'],
+        fontWeight:
+          tokenGroup === 'fontweight'
+            ? typography[token[0]].value
+            : theme.tokens['typography-fontweight-normal'],
+        lineHeight:
+          tokenGroup === 'lineheight'
+            ? typography[token[0]]?.value
+            : theme.tokens['typography-lineheight-default'],
+        overflow: 'hidden',
+        textDecoration:
+          tokenGroup === 'textdecoration'
+            ? typography[token[0]]?.value
+            : theme.tokens['typography-textdecoration-none'],
+        WebkitBoxOrient: 'vertical',
+        WebkitLineClamp: tokenGroup === 'fontsize' ? '1' : 'unset',
+      },
+    },
+  };
+
+  return (
+    <Stack alignItems="center" direction="row" gap={3}>
+      {tokenType === 'typography' ? (
+        <Box sx={previewMap[tokenType].sx}>
+          Get food you can rely on for your meetings and events — professionally prepared and
+          delivered.
+        </Box>
+      ) : (
+        <Box borderRadius="4px" height="40px" minWidth="40px" sx={previewMap[tokenType].sx} />
+      )}
+      <Box>{previewMap[tokenType].displayText}</Box>
+    </Stack>
+  );
+};
+
+export default DesignTokenPreview;

--- a/packages/recipe/docs/components/DesignTokens/DesignTokens.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokens.tsx
@@ -9,13 +9,12 @@ type TokenType = {
   group: boolean;
 };
 
-// TODO: add remaining tokens
 const TOKEN_TYPES: Array<TokenType> = [
   {type: 'color', group: true},
   {type: 'radius', group: false},
   {type: 'shadow', group: false},
   {type: 'spacing', group: false},
-  // {type: 'typography', group: false},
+  {type: 'typography', group: true},
 ];
 
 const getTokens = (themeTokens: EzThemeTokens, tokenType: string) => {
@@ -24,15 +23,15 @@ const getTokens = (themeTokens: EzThemeTokens, tokenType: string) => {
 };
 
 const DesignTokensPanel = ({children, index, value, ...args}: DesignTokensPanelProps) => (
-  <div
+  <Box
     role="tabpanel"
     hidden={value !== index}
     id={`design-tokens-panel-${index}`}
     aria-labelledby={`design-tokens-${index}`}
     {...args}
   >
-    {value === index && <Box py={3}>{children}</Box>}
-  </div>
+    {value === index && <Box my={3}>{children}</Box>}
+  </Box>
 );
 
 const DesignTokens: FC<unknown> = () => {

--- a/packages/recipe/docs/components/DesignTokens/DesignTokens.types.ts
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokens.types.ts
@@ -1,5 +1,21 @@
 import type {ReactNode} from 'react';
-import {EzThemeTokens, EzTokenTypes} from '../../../src/themes/themes.types';
+import {EzTokenTypes} from '../../../src/themes/themes.types';
+
+export type GroupedTokens = {
+  displayName: string;
+  name: string;
+  tokens: Array<Array<string>>;
+};
+
+export interface CodeBlockProps {
+  children: string;
+  withCopy?: boolean;
+}
+
+export interface CopyButtonProps {
+  darkMode?: boolean;
+  textToCopy: string;
+}
 
 export interface DesignTokensPanelProps {
   children?: ReactNode;
@@ -9,6 +25,16 @@ export interface DesignTokensPanelProps {
 
 export interface DesignTokensDisplayProps {
   groupTokens: boolean;
+  tokens: Array<Array<string>>;
+  tokenType: EzTokenTypes;
+}
+
+export interface DesignTokenPreviewProps {
+  token: Array<string>;
+  tokenType: EzTokenTypes;
+}
+
+export interface DesignTokensTableProps {
   tokens: Array<Array<string>>;
   tokenType: EzTokenTypes;
 }

--- a/packages/recipe/docs/components/DesignTokens/DesignTokensDisplay.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokensDisplay.tsx
@@ -1,156 +1,61 @@
-import React from 'react';
-import {
-  Box,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  useTheme,
-} from '@mui/material';
-import {color as storybookColor} from '@storybook/theming';
-import {color, radius, shadow, spacing} from '../../../src/themes/tokens';
-import {DesignTokensDisplayProps} from './DesignTokens.types';
-import CopyButton from './CopyButton';
-
-const CodeBlock = ({children, withCopy = false}) => {
-  const theme = useTheme();
-
-  return (
-    <Box position="relative">
-      <Box
-        bgcolor={theme.tokens['color-surface-neutral-bold']}
-        borderRadius="4px"
-        overflow="auto"
-        pl={2}
-        pr={withCopy ? 4 : 2}
-      >
-        <Box aria-hidden={true} color={theme.tokens['color-text-contrast']} component="pre" my={1}>
-          <Box component="code" whiteSpace="pre-wrap">
-            {children}
-          </Box>
-        </Box>
-      </Box>
-
-      {withCopy && (
-        <Box position="absolute" top="4px" right="4px">
-          <CopyButton darkMode textToCopy={children} />
-        </Box>
-      )}
-    </Box>
-  );
-};
-
-const DesignTokenPreview = ({token, tokenType}) => {
-  const theme = useTheme();
-
-  // TODO: add remaining tokens
-  const previewMap = {
-    color: {
-      displayText: color[token[0]]?.displayText,
-      sx: {bgcolor: color[token[0]]?.value},
-    },
-    radius: {
-      displayText: radius[token[0]]?.displayText,
-      sx: {
-        backgroundColor: theme.tokens['color-surface-neutral-default'],
-        borderRadius: radius[token[0]]?.value,
-      },
-    },
-    shadow: {
-      displayText: shadow[token[0]]?.displayText,
-      sx: {boxShadow: shadow[token[0]]?.value},
-    },
-    spacing: {
-      displayText: spacing[token[0]]?.displayText,
-      sx: {
-        backgroundColor: theme.tokens['color-surface-neutral-default'],
-        borderRadius: theme.tokens['radius-none'],
-        minWidth: spacing[token[0]]?.value,
-      },
-    },
-    // typography: {style: 'fontFamily'},
-  };
-
-  return (
-    <Stack alignItems="center" direction="row" gap={3}>
-      <Box borderRadius="4px" height="40px" minWidth="40px" sx={previewMap[tokenType].sx} />
-      <Box>{previewMap[tokenType].displayText}</Box>
-    </Stack>
-  );
-};
-
-type GroupedTokens = {
-  name: string;
-  tokens: Array<Array<string>>;
-};
-
-type TokenRowProps = {
-  groupedTokens?: GroupedTokens;
-  includeGroup?: boolean;
-  token: Array<string>;
-  tokenType: string;
-};
-
-const TokenRow = ({includeGroup, groupedTokens, token, tokenType}: TokenRowProps) => (
-  <TableRow sx={{'&:last-child td, &:last-child th': {border: 0}}}>
-    {includeGroup && (
-      <TableCell rowSpan={groupedTokens.tokens.length}>{groupedTokens.name}</TableCell>
-    )}
-    <TableCell>
-      <CodeBlock withCopy>{token[0]}</CodeBlock>
-    </TableCell>
-    <TableCell sx={{maxWidth: '300px'}}>
-      <CodeBlock>{token[1]}</CodeBlock>
-    </TableCell>
-    <TableCell sx={{minWidth: '300px'}}>
-      <DesignTokenPreview token={token} tokenType={tokenType} />
-    </TableCell>
-  </TableRow>
-);
+import React, {useState} from 'react';
+import {Box, Tab, Tabs, useTheme} from '@mui/material';
+import {DesignTokensDisplayProps, GroupedTokens} from './DesignTokens.types';
+import DesignTokensTable from './DesignTokensTable';
 
 const DesignTokensDisplay = ({tokens, tokenType, groupTokens}: DesignTokensDisplayProps) => {
-  const cellStyles = {color: storybookColor.darkest, fontWeight: 'bold', opacity: 0.6};
+  const [value, setValue] = useState(0);
+  const theme = useTheme();
 
   let groupedTokens: GroupedTokens[] | undefined;
   if (groupTokens) {
     const tokenGroupNames = new Set(tokens.map(token => token[0].split('-')[1]));
     groupedTokens = [...tokenGroupNames].map((tokenGroupName: string) => {
       return {
+        displayName: tokenGroupName.replace(/^(line|font|text)(.+)$/gi, '$1 $2').trim(),
         name: tokenGroupName,
         tokens: tokens.filter(token => token[0].includes(`-${tokenGroupName}-`)),
       };
     });
+
+    return (
+      <>
+        <Box bgcolor={theme.tokens['color-surface-subtle']} mt={-3}>
+          <Tabs
+            aria-label="design tokens"
+            onChange={(_event, newValue) => setValue(newValue)}
+            value={value}
+          >
+            {groupedTokens.map(({displayName, name}) => (
+              <Tab
+                key={name}
+                label={displayName}
+                id={`grouped-tokens-${name}`}
+                aria-controls={`grouped-tokens-panel-${name}`}
+              />
+            ))}
+          </Tabs>
+        </Box>
+        {groupedTokens.map(({name, tokens}, index) => (
+          <div
+            aria-labelledby={`design-tokens-${index}`}
+            hidden={value !== index}
+            id={`design-tokens-panel-${index}`}
+            key={name}
+            role="tabpanel"
+          >
+            {value === index && (
+              <Box py={3}>
+                <DesignTokensTable tokens={tokens} tokenType={tokenType} />
+              </Box>
+            )}
+          </div>
+        ))}
+      </>
+    );
   }
 
-  return (
-    <Table aria-label="design tokens display" size="small">
-      <TableHead>
-        <TableRow>
-          {groupedTokens && <TableCell />}
-          <TableCell sx={{...cellStyles, minWidth: '320px'}}>Name</TableCell>
-          <TableCell sx={cellStyles}>Value</TableCell>
-          <TableCell sx={cellStyles}>Preview</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {groupedTokens
-          ? groupedTokens.flatMap(tokenGroup =>
-              tokenGroup.tokens.map((token, index) => (
-                <TokenRow
-                  groupedTokens={tokenGroup}
-                  includeGroup={index === 0}
-                  key={token[0]}
-                  token={token}
-                  tokenType={tokenType}
-                />
-              ))
-            )
-          : tokens.map(token => <TokenRow key={token[0]} token={token} tokenType={tokenType} />)}
-      </TableBody>
-    </Table>
-  );
+  return <DesignTokensTable tokens={tokens} tokenType={tokenType} />;
 };
 
 export default DesignTokensDisplay;

--- a/packages/recipe/docs/components/DesignTokens/DesignTokensTable.tsx
+++ b/packages/recipe/docs/components/DesignTokens/DesignTokensTable.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {Table, TableBody, TableCell, TableHead, TableRow} from '@mui/material';
+import {color as storybookColor} from '@storybook/theming';
+import {DesignTokensTableProps} from './DesignTokens.types';
+import CodeBlock from './CodeBlock';
+import DesignTokenPreview from './DesignTokenPreview';
+
+const DesignTokensTable = ({tokens, tokenType}: DesignTokensTableProps) => {
+  const cellStyles = {color: storybookColor.darkest, fontWeight: 'bold', opacity: 0.6};
+
+  return (
+    <Table aria-label="design tokens display" size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell sx={{...cellStyles, minWidth: '300px'}}>Name</TableCell>
+          <TableCell sx={cellStyles}>Value</TableCell>
+          <TableCell sx={cellStyles}>Preview</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {tokens.map((token: Array<string>) => (
+          <TableRow key={token[0]} sx={{'&:last-child td, &:last-child th': {border: 0}}}>
+            <TableCell>
+              <CodeBlock withCopy>{token[0]}</CodeBlock>
+            </TableCell>
+            <TableCell sx={{maxWidth: '120px'}}>
+              <CodeBlock>{token[1]}</CodeBlock>
+            </TableCell>
+            <TableCell>
+              <DesignTokenPreview token={token} tokenType={tokenType} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default DesignTokensTable;

--- a/packages/recipe/docs/guides/GettingStarted.mdx
+++ b/packages/recipe/docs/guides/GettingStarted.mdx
@@ -118,17 +118,28 @@ const MyOtherComponent = styled.div`
 `;
 ```
 
-### Including Recipe's default font
+### Including Recipe's default fonts
 
 To ensure Recipe's default fonts are available in a webpage, copy this code into the `<head>` of your HTML document.
 
 ```html
+<!-- Montserrat and Roboto Flex (deprecated) from Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
-  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
+  rel="preload"
+  as="style"
+  crossorigin
 />
+<link
+  href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
+  rel="stylesheet"
+  crossorigin
+/>
+<!-- Lato and Roboto from Adobe Fonts -->
+<link as="style" href="https://use.typekit.net/dnm5yzr.css" rel="preload" crossorigin />
+<link href="https://use.typekit.net/dnm5yzr.css" rel="stylesheet" crossorigin />
 ```
 
 ## Development setup

--- a/packages/recipe/playroom/FrameComponent.tsx
+++ b/packages/recipe/playroom/FrameComponent.tsx
@@ -7,12 +7,23 @@ export default function FrameComponent({theme, children}) {
 
   return (
     <>
+      {/* Montserrat and Roboto Flex (deprecated) from Google Fonts */}
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
       <link
-        href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
-        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
+        rel="preload"
+        as="style"
+        crossOrigin=""
       />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Flex:opsz,wght@8..144,100;8..144,200;8..144,300;8..144,400;8..144,500;8..144,600;8..144,700;8..144,800;8..144,900;8..144,1000&display=swap"
+        rel="stylesheet"
+        crossOrigin=""
+      />
+      {/* Lato and Roboto from Adobe Fonts */}
+      <link as="style" href="https://use.typekit.net/dnm5yzr.css" rel="preload" crossOrigin="" />
+      <link href="https://use.typekit.net/dnm5yzr.css" rel="stylesheet" crossOrigin="" />
       <EzGlobalStyles />
       <EzProvider theme={isMarketplaceTheme ? stitchesMarketplaceTheme : undefined}>
         <EzThemeProvider theme={theme}>{children}</EzThemeProvider>

--- a/packages/recipe/src/themes/mui/ezTheme.ts
+++ b/packages/recipe/src/themes/mui/ezTheme.ts
@@ -1,7 +1,7 @@
 import {createTheme, responsiveFontSizes} from '@mui/material';
 import {ezPalette, legacyColors} from '../ezColors';
 import type {EzPaletteOptions, EzThemeTokens} from '../themes.types';
-import {color, radius, shadow, spacing} from '../tokens';
+import {color, radius, shadow, spacing, typography} from '../tokens';
 
 declare module '@mui/material/styles/createTheme' {
   interface Theme {
@@ -153,7 +153,7 @@ const palette: EzPaletteOptions = {
 
 const defaultFont = 'Lato, "Helvetica Neue", Arial, Helvetica, sans-serif';
 
-const typography = {
+const themeTypography = {
   defaultFont,
   fontFamily: defaultFont,
   headerFont: defaultFont,
@@ -383,8 +383,9 @@ const ezTheme = responsiveFontSizes(
       ...getTokens(radius),
       ...getTokens(shadow),
       ...getTokens(spacing),
+      ...getTokens(typography),
     },
-    typography,
+    typography: themeTypography,
   })
 );
 

--- a/packages/recipe/src/themes/tokens/index.ts
+++ b/packages/recipe/src/themes/tokens/index.ts
@@ -2,3 +2,4 @@ export {color} from './color';
 export {radius} from './radius';
 export {shadow} from './shadow';
 export {spacing} from './spacing';
+export {typography} from './typography';

--- a/packages/recipe/src/themes/tokens/typography.ts
+++ b/packages/recipe/src/themes/tokens/typography.ts
@@ -1,0 +1,63 @@
+const FONT_SIZE_MAP = {
+  25: {displayText: '12px', value: '0.75rem'},
+  50: {displayText: '14px', value: '0.875rem'},
+  100: {displayText: '16px', value: '1rem'},
+  200: {displayText: '20px', value: '1.25rem'},
+  300: {displayText: '24px', value: '1.5rem'},
+  400: {displayText: '28px', value: '1.75rem'},
+  500: {displayText: '32px', value: '2rem'},
+  600: {displayText: '40px', value: '2.5rem'},
+  700: {displayText: '48px', value: '3rem'},
+  800: {displayText: '56px', value: '3.5rem'},
+  900: {displayText: '64px', value: '4rem'},
+};
+
+const fontFamilyTokens = {
+  'typography-fontfamily-demand': {
+    value: 'Lato, "Helvetica Neue", Arial, Helvetica, sans-serif',
+  },
+  'typography-fontfamily-supply': {
+    value: 'Roboto, "Helvetica Neue", Arial, Helvetica, sans-serif',
+  },
+};
+
+const fontSizeTokens = Object.keys(FONT_SIZE_MAP).reduce(
+  (tokens, fontSizeKey) => ({
+    ...tokens,
+    [`typography-fontsize-${fontSizeKey}`]: {
+      displayText: `(${FONT_SIZE_MAP[fontSizeKey].displayText})`,
+      value: FONT_SIZE_MAP[fontSizeKey].value,
+    },
+  }),
+  {}
+);
+
+const lineHeightTokens = {
+  'typography-lineheight-default': {value: '1.45em'},
+  'typography-lineheight-dense': {value: '1.2em'},
+};
+
+const fontStyleTokens = {
+  'typography-fontstyle-normal': {value: 'normal'},
+  'typography-fontstyle-italic': {value: 'italic'},
+};
+
+const fontWeightTokens = {
+  'typography-fontweight-normal': {value: '400'},
+  'typography-fontweight-semibold': {value: '600'},
+  'typography-fontweight-bold': {value: '700'},
+};
+
+const textDecorationTokens = {
+  'typography-textdecoration-none': {value: 'none'},
+  'typography-textdecoration-underline': {value: 'underline'},
+};
+
+export const typography = {
+  ...fontFamilyTokens,
+  ...fontSizeTokens,
+  ...lineHeightTokens,
+  ...fontStyleTokens,
+  ...fontWeightTokens,
+  ...textDecorationTokens,
+};


### PR DESCRIPTION
## What did we change?
- [style: add typography design tokens to themes and update fonts](https://github.com/ezcater/recipe/commit/70637f16c466978c76dd085de2551aed0982d0bf)

## Why are we doing this?
Added typography design tokens in Recipe themes including documentation. This does not update any of our components to use these new design tokens. That will be done in a separate PR.

Note: Google Fonts [does not support](https://github.com/google/fonts/issues/1415) semibold (`500`) for Lato. Instead, we have to get it from Adobe Fonts. As we're moving to Lato and Roboto, this PR adds both using Adobe Fonts, then removes Lato from Google Fonts and keeps Montserrat and Roboto Flex as deprecated fonts from Google Fonts. Once we remove them, we will only be using Adobe Fonts. This is a non-breaking change until then.

## Screenshot(s) / Gif(s):
<img width="1702" alt="Screenshot 2023-10-18 at 2 10 48 PM" src="https://github.com/ezcater/recipe/assets/5418735/71a7319e-6762-494b-aad0-1b16354b7d56">
<img width="1035" alt="Screenshot 2023-10-18 at 2 10 59 PM" src="https://github.com/ezcater/recipe/assets/5418735/2dd559a3-b7f8-42ec-b4b1-9cbef0191f77">
<img width="1077" alt="Screenshot 2023-10-18 at 2 11 09 PM" src="https://github.com/ezcater/recipe/assets/5418735/88c82e36-dd82-4355-8b6e-4dd1c03d3354">
<img width="1034" alt="Screenshot 2023-10-18 at 2 11 19 PM" src="https://github.com/ezcater/recipe/assets/5418735/500db08a-53e9-488e-aa1d-87cc2965eafb">
<img width="1036" alt="Screenshot 2023-10-18 at 2 11 29 PM" src="https://github.com/ezcater/recipe/assets/5418735/916d54c6-1ca8-4e21-9a0c-2918437c0137">
<img width="1032" alt="Screenshot 2023-10-18 at 2 11 38 PM" src="https://github.com/ezcater/recipe/assets/5418735/eb5bef73-988d-4735-b9af-6858400d04fa">

## Checklist
- [x] Create a changeset (`yarn changeset`) with a summary of the changes